### PR TITLE
Improve company lookup prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ The repository also contains a simple helper, `fetch_company_web_info`, in
 company from the web. The helper expects an ``OPENAI_API_KEY`` environment
 variable and, optionally, an ``OPENAI_MODEL`` variable to choose the model. If no
 model is specified, it defaults to ``gpt-4o``.
+
+You may provide just the company name or pass a `Company` object returned from
+`read_companies_from_csv`. When a dataclass is supplied, all details from the CSV
+are included in the prompt sent to the LLM so that it can give a more informed
+summary.

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+# Provide a minimal openai stub if the real package is unavailable
+if 'openai' not in sys.modules:
+    openai_stub = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **kwargs: None))
+    sys.modules['openai'] = openai_stub
+
+from parser import Company
+from company_lookup import fetch_company_web_info
+
+
+class TestFetchCompanyWebInfo(unittest.TestCase):
+    @patch('company_lookup.openai.ChatCompletion.create')
+    def test_prompt_includes_csv_details(self, mock_create):
+        os.environ['OPENAI_API_KEY'] = 'test-key'
+        mock_create.return_value = type('Resp', (), {
+            'choices': [type('Choice', (), {'message': {'content': 'ok'}})]
+        })
+
+        company = Company(
+            organization_name="Acme Corp",
+            organization_name_url="https://acme.example.com",
+            estimated_revenue_range="$10M-$50M",
+            ipo_status="Private",
+            operating_status="Operating",
+            acquisition_status=None,
+            company_type="For Profit",
+            number_of_employees="100-250",
+            full_description="Acme Corp specializes in gadgets and gizmos.",
+            industries="Manufacturing",
+            headquarters_location="New York, NY",
+            description="Leading gadget manufacturer",
+            cb_rank="1",
+        )
+
+        fetch_company_web_info(company, model="test-model")
+
+        args, kwargs = mock_create.call_args
+        self.assertEqual(kwargs['model'], 'test-model')
+        user_content = kwargs['messages'][1]['content']
+        self.assertIn("Acme Corp", user_content)
+        self.assertIn("Estimated Revenue Range: $10M-$50M", user_content)
+        self.assertIn("Headquarters Location: New York, NY", user_content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fetch_company_web_info now accepts a `Company` instance and includes CSV details in the prompt
- document the improved helper in README
- add tests for new functionality

## Testing
- `python3 -m tests.test_parser`
- `python3 -m tests.test_company_lookup`
