### PR TITLE
Fix env var management in tests

### DIFF
--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -16,35 +16,35 @@ from company_lookup import fetch_company_web_info
 class TestFetchCompanyWebInfo(unittest.TestCase):
     @patch('company_lookup.openai.ChatCompletion.create')
     def test_prompt_includes_csv_details(self, mock_create):
-        os.environ['OPENAI_API_KEY'] = 'test-key'
         mock_create.return_value = type('Resp', (), {
             'choices': [type('Choice', (), {'message': {'content': 'ok'}})]
         })
 
-        company = Company(
-            organization_name="Acme Corp",
-            organization_name_url="https://acme.example.com",
-            estimated_revenue_range="$10M-$50M",
-            ipo_status="Private",
-            operating_status="Operating",
-            acquisition_status=None,
-            company_type="For Profit",
-            number_of_employees="100-250",
-            full_description="Acme Corp specializes in gadgets and gizmos.",
-            industries="Manufacturing",
-            headquarters_location="New York, NY",
-            description="Leading gadget manufacturer",
-            cb_rank="1",
-        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            company = Company(
+                organization_name="Acme Corp",
+                organization_name_url="https://acme.example.com",
+                estimated_revenue_range="$10M-$50M",
+                ipo_status="Private",
+                operating_status="Operating",
+                acquisition_status=None,
+                company_type="For Profit",
+                number_of_employees="100-250",
+                full_description="Acme Corp specializes in gadgets and gizmos.",
+                industries="Manufacturing",
+                headquarters_location="New York, NY",
+                description="Leading gadget manufacturer",
+                cb_rank="1",
+            )
 
-        fetch_company_web_info(company, model="test-model")
+            fetch_company_web_info(company, model="test-model")
 
-        args, kwargs = mock_create.call_args
-        self.assertEqual(kwargs['model'], 'test-model')
-        user_content = kwargs['messages'][1]['content']
-        self.assertIn("Acme Corp", user_content)
-        self.assertIn("Estimated Revenue Range: $10M-$50M", user_content)
-        self.assertIn("Headquarters Location: New York, NY", user_content)
+            args, kwargs = mock_create.call_args
+            self.assertEqual(kwargs['model'], 'test-model')
+            user_content = kwargs['messages'][1]['content']
+            self.assertIn("Acme Corp", user_content)
+            self.assertIn("Estimated Revenue Range: $10M-$50M", user_content)
+            self.assertIn("Headquarters Location: New York, NY", user_content)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- ensure `OPENAI_API_KEY` is patched with `patch.dict`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*