### PR TITLE
Implement async parallel company lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ For convenience, the repository provides a small CLI script, `lookup_companies.p
 which reads a CSV file and uses `fetch_company_web_info` to retrieve summaries for
 each company. The script processes only a limited number of rows (default is 5)
 and issues a warning if the CSV contains more than 100 lines.
+The tool now fetches results in parallel using asynchronous API calls. You can
+control the level of concurrency with the `--max-concurrency` flag (default is 5).
 
 ```bash
-python lookup_companies.py path/to/companies.csv --max-lines 5
+python lookup_companies.py path/to/companies.csv --max-lines 5 --max-concurrency 10
 ```
 
 This will print summaries for the first few companies in the spreadsheet.

--- a/company_lookup.py
+++ b/company_lookup.py
@@ -65,3 +65,53 @@ def fetch_company_web_info(
         return message.get("content")
     return getattr(message, "content", None)
 
+
+async def async_fetch_company_web_info(
+    company: Union[str, Company], model: Optional[str] = None
+) -> Optional[str]:
+    """Asynchronously fetch company info using OpenAI."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+
+    client = openai.AsyncOpenAI(api_key=api_key)
+
+    model_name = model or os.getenv("OPENAI_MODEL") or "gpt-4o"
+
+    if isinstance(company, str):
+        company_name = company
+        csv_details = ""
+    else:
+        company_name = company.organization_name
+        info = asdict(company)
+        info.pop("organization_name", None)
+        lines = [f"{k.replace('_', ' ').title()}: {v}" for k, v in info.items() if v]
+        csv_details = "\n".join(lines)
+
+    prompt = f"Search the web for information about {company_name}. "
+    if csv_details:
+        prompt += "Here is what we already know from a CSV:\n" + csv_details + "\n"
+    prompt += (
+        "Summarize the company's business model, data strategy, and likely "
+        "stance on interoperability and access legislation."
+    )
+
+    response = await client.chat.completions.create(
+        model=model_name,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are an assistant that can access web search results "
+                    "to provide up-to-date company information."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ],
+    )
+
+    message = response.choices[0].message
+    if isinstance(message, dict):
+        return message.get("content")
+    return getattr(message, "content", None)
+

--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -3,12 +3,14 @@
 
 from argparse import ArgumentParser
 from pathlib import Path
+import asyncio
 
 from parser import read_companies_from_csv
-from company_lookup import fetch_company_web_info
+from company_lookup import async_fetch_company_web_info
 
 
 DEFAULT_MAX_LINES = 5
+DEFAULT_MAX_CONCURRENCY = 5
 
 
 def main() -> None:
@@ -16,6 +18,12 @@ def main() -> None:
     parser.add_argument("csv", type=Path, help="CSV file containing company data")
     parser.add_argument("--max-lines", type=int, default=DEFAULT_MAX_LINES,
                         help=f"Number of lines to process (default: {DEFAULT_MAX_LINES})")
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=DEFAULT_MAX_CONCURRENCY,
+        help=f"Maximum concurrent API requests (default: {DEFAULT_MAX_CONCURRENCY})",
+    )
     args = parser.parse_args()
 
     companies = read_companies_from_csv(args.csv)
@@ -29,16 +37,26 @@ def main() -> None:
 
     to_process = companies[: args.max_lines]
 
-    for idx, company in enumerate(to_process, start=1):
-        print(f"\n[{idx}/{len(to_process)}] Fetching info for: {company.organization_name}")
-        try:
-            summary = fetch_company_web_info(company.organization_name)
-        except Exception as exc:
-            print(f"Error fetching info for {company.organization_name}: {exc}")
-            continue
+    asyncio.run(_run_async(to_process, args.max_concurrency))
 
-        if summary:
-            print(summary)
+
+async def _run_async(companies, max_concurrency: int) -> None:
+    semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def fetch(company):
+        async with semaphore:
+            return await async_fetch_company_web_info(company.organization_name)
+
+    tasks = [asyncio.create_task(fetch(c)) for c in companies]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for idx, result in enumerate(results, start=1):
+        company = companies[idx - 1]
+        print(f"\n[{idx}/{len(companies)}] Result for: {company.organization_name}")
+        if isinstance(result, Exception):
+            print(f"Error fetching info for {company.organization_name}: {result}")
+        elif result:
+            print(result)
         else:
             print("No summary returned.")
 


### PR DESCRIPTION
## Summary
- add `async_fetch_company_web_info` to make asynchronous OpenAI calls
- fetch company info in parallel in `lookup_companies.py`
- document new `--max-concurrency` option in README

## Testing
- `python -m unittest discover -s tests -v`