### PR TITLE
Add structured output parsing for company lookup

### DIFF
--- a/company_lookup.py
+++ b/company_lookup.py
@@ -1,6 +1,8 @@
 import os
 from dataclasses import asdict
 from typing import Optional, Union
+import json
+import re
 
 from parser import Company
 
@@ -43,7 +45,10 @@ def fetch_company_web_info(
         prompt += "Here is what we already know from a CSV:\n" + csv_details + "\n"
     prompt += (
         "Summarize the company's business model, data strategy, and likely "
-        "stance on interoperability and access legislation."
+        "stance on interoperability and access legislation. "
+        "End with a JSON code block containing the key 'stance' and the "
+        "model's single-sentence assessment, for example:\n"
+        "```json\n{\"stance\": \"supportive\"}\n```"
     )
 
     response = client.chat.completions.create(
@@ -64,4 +69,25 @@ def fetch_company_web_info(
     if isinstance(message, dict):
         return message.get("content")
     return getattr(message, "content", None)
+
+
+def parse_llm_response(response: str) -> Optional[str]:
+    """Extract the stance value from the JSON markdown block in the LLM response."""
+
+    if not response:
+        return None
+
+    match = re.search(r"```json\s*(\{.*?\})\s*```", response, re.DOTALL)
+    if not match:
+        return None
+
+    try:
+        data = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return None
+
+    stance = data.get("stance")
+    if stance is not None:
+        stance = str(stance).strip()
+    return stance
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -20,7 +20,7 @@ if 'openai' not in sys.modules:
     sys.modules['openai'] = openai_stub
 
 from parser import Company
-from company_lookup import fetch_company_web_info
+from company_lookup import fetch_company_web_info, parse_llm_response
 
 
 class TestFetchCompanyWebInfo(unittest.TestCase):
@@ -58,6 +58,16 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
             self.assertIn("Acme Corp", user_content)
             self.assertIn("Estimated Revenue Range: $10M-$50M", user_content)
             self.assertIn("Headquarters Location: New York, NY", user_content)
+            self.assertIn("key 'stance'", user_content)
+
+    def test_parse_llm_response(self):
+        text = (
+            "Acme summary.\n"
+            "```json\n"
+            '{"stance": "supportive"}'
+            "\n```"
+        )
+        self.assertEqual(parse_llm_response(text), "supportive")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- enforce JSON code block in OpenAI prompt so stance can be parsed
- implement `parse_llm_response` helper to grab stance from markdown
- test that prompt includes new instruction and parser works

## Testing
- `python -m unittest discover -s tests -v`