### PR TITLE
Change supportive key to scalar

### DIFF
--- a/company_lookup.py
+++ b/company_lookup.py
@@ -58,7 +58,13 @@ def fetch_company_web_info(
         prompt += "Here is what we already know from a CSV:\n" + csv_details + "\n"
     prompt += (
         "Summarize the company's business model, data strategy, and likely "
-        "stance on interoperability and access legislation."
+        "stance on interoperability and access legislation. "
+        "Rate their support on a scale from 0 (strong opponent) to 1 (strong proponent). "
+        "End with a JSON code block containing the key 'supportive' with this number. "
+        "For example:\n"
+        "```json\n{\"supportive\": 0.8}\n``` "
+        "Mozilla and the Electronic Frontier Foundation would be close to 1, "
+        "while Meta and Palantir might be near 0."
     )
 
     cache_dir = Path.home() / "llm_cache"
@@ -124,9 +130,12 @@ async def async_fetch_company_web_info(
     prompt += (
         "Summarize the company's business model, data strategy, and likely "
         "stance on interoperability and access legislation. "
-        "End with a JSON code block containing the key 'stance' and the "
-        "model's single-sentence assessment, for example:\n"
-        "```json\n{\"stance\": \"supportive\"}\n```"
+        "Rate their support on a scale from 0 (strong opponent) to 1 (strong proponent). "
+        "End with a JSON code block containing the key 'supportive' with this number. "
+        "For example:\n"
+        "```json\n{\"supportive\": 0.8}\n``` "
+        "Mozilla and the Electronic Frontier Foundation would be close to 1, "
+        "while Meta and Palantir might be near 0."
     )
 
     response = await client.chat.completions.create(
@@ -149,8 +158,8 @@ async def async_fetch_company_web_info(
     return getattr(message, "content", None)
 
 
-def parse_llm_response(response: str) -> Optional[str]:
-    """Extract the stance value from the JSON markdown block in the LLM response."""
+def parse_llm_response(response: str) -> Optional[float]:
+    """Extract the numeric `supportive` value from the JSON markdown block in the LLM response."""
 
     if not response:
         return None
@@ -164,8 +173,29 @@ def parse_llm_response(response: str) -> Optional[str]:
     except json.JSONDecodeError:
         return None
 
-    stance = data.get("stance")
-    if stance is not None:
-        stance = str(stance).strip()
-    return stance
+    supportive = data.get("supportive")
+    if supportive is None:
+        return None
+
+    if isinstance(supportive, (int, float)):
+        value = float(supportive)
+        if 0.0 <= value <= 1.0:
+            return value
+        return None
+
+    text = str(supportive).strip().lower()
+    if text in {"true", "yes"}:
+        return 1.0
+    if text in {"false", "no"}:
+        return 0.0
+
+    match_num = re.search(r"-?\d*\.?\d+", text)
+    if match_num:
+        try:
+            value = float(match_num.group())
+            if 0.0 <= value <= 1.0:
+                return value
+        except ValueError:
+            pass
+    return None
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -60,16 +60,20 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
             self.assertIn("Acme Corp", user_content)
             self.assertIn("Estimated Revenue Range: $10M-$50M", user_content)
             self.assertIn("Headquarters Location: New York, NY", user_content)
-            self.assertIn("key 'stance'", user_content)
+            self.assertIn("key 'supportive'", user_content)
+            self.assertIn("scale from 0 (strong opponent) to 1 (strong proponent)", user_content)
+            self.assertIn("Mozilla", user_content)
 
     def test_parse_llm_response(self):
         text = (
             "Acme summary.\n"
             "```json\n"
-            '{"stance": "supportive"}'
+            '{"supportive": 0.75}'
             "\n```"
         )
-        self.assertEqual(parse_llm_response(text), "supportive")
+        result = parse_llm_response(text)
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result, 0.75)
 
     @patch('company_lookup.openai.OpenAI')
     def test_cache_reused_for_same_seed(self, mock_openai):


### PR DESCRIPTION
## Summary
- return supportive stance as numeric value between 0 and 1
- add proponent/opponent examples in prompt
- handle numeric parsing in parser
- update tests for new scale output

## Testing
- `python -m unittest discover -s tests -v`
