### PR TITLE
Increase default max lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ summary.
 
 For convenience, the repository provides a small CLI script, `lookup_companies.py`,
 which reads a CSV file and uses `fetch_company_web_info` to retrieve summaries for
-each company. The script processes only a limited number of rows (default is 5)
+each company. The script processes only a limited number of rows (default is 10)
 and issues a warning if the CSV contains more than 100 lines.
 The tool now fetches results in parallel using asynchronous API calls. You can
 control the level of concurrency with the `--max-concurrency` flag (default is 5).
 
 ```bash
-python lookup_companies.py path/to/companies.csv --max-lines 5 --max-concurrency 10
+python lookup_companies.py path/to/companies.csv --max-lines 10 --max-concurrency 10
 ```
 
 This will print summaries for the first few companies in the spreadsheet.

--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -11,7 +11,7 @@ from company_lookup import async_fetch_company_web_info, parse_llm_response
 import re
 
 
-DEFAULT_MAX_LINES = 5
+DEFAULT_MAX_LINES = 10
 DEFAULT_MAX_CONCURRENCY = 5
 
 


### PR DESCRIPTION
## Summary
- increase `DEFAULT_MAX_LINES` in `lookup_companies.py`
- update README example and description

## Testing
- `python -m unittest discover -s tests -v`