### PR TITLE
Scale bar charts in final report

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -81,9 +81,18 @@ def generate_final_report(companies: List[Company], stances: List[Optional[float
     lines.append(f"Overall {total_support}/{total_companies} companies are supportive.")
 
     lines.append("\nSupportive companies by industry:")
+    max_bar_width = 20
+    max_support = max((d["supportive"] for d in industry_data.values()), default=0)
+    if max_support == 0:
+        max_support = 1
     for ind in sorted(industry_data):
         d = industry_data[ind]
-        bar = "#" * d["supportive"]
+        proportion = d["supportive"] / max_support
+        bar_len = int(round(proportion * max_bar_width)) if d["supportive"] else 0
+        # Ensure at least one character is shown for non-zero counts
+        if d["supportive"] > 0 and bar_len == 0:
+            bar_len = 1
+        bar = "#" * bar_len
         lines.append(f"  {ind}: {bar} ({d['supportive']}/{d['total']})")
 
     lines.append("\nAverage stance per industry:")

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -174,6 +174,9 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("Software: supportive company found", report)
         self.assertIn("Overall 2/3 companies are supportive", report)
         self.assertIn("Supportive companies by industry", report)
+        self.assertIn("  Manufacturing: #################### (1/1)", report)
+        self.assertIn("  Software: #################### (1/1)", report)
+        self.assertIn("  Technology:  (0/1)", report)
         self.assertIn("Average stance per industry", report)
         self.assertIn("Supportive companies tend to be smaller", report)
 


### PR DESCRIPTION
## Summary
- scale bar width in `generate_final_report` up to a maximum of 20 characters
- expect scaled bar output in the final report test

## Testing
- `python -m unittest discover -s tests -v`