### PR TITLE
Improve _industry filtering

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -27,11 +27,23 @@ def _employee_count(company: Company) -> Optional[float]:
 
 
 def _industry(company: Company) -> str:
-    """Return the first listed industry for the company."""
+    """Return a sanitized industry string for the company."""
+
     if not company.industries:
         return "Unknown"
-    parts = re.split(r"[;,]", company.industries)
-    return parts[0].strip() or "Unknown"
+
+    part = re.split(r"[;,]", company.industries)[0]
+    part = part.strip()
+    # Remove URLs and other obvious web references
+    part = re.sub(r"https?://\S+|www\.[^\s]+", "", part)
+    part = part.strip()
+
+    # Discard unusually long text fragments that likely aren't simple
+    # industry names.
+    if len(part.split()) > 4:
+        return "Unknown"
+
+    return part or "Unknown"
 
 
 def generate_final_report(companies: List[Company], stances: List[Optional[float]]) -> str:

--- a/tests/test_lookup_companies.py
+++ b/tests/test_lookup_companies.py
@@ -1,0 +1,41 @@
+import unittest
+from parser import Company
+from lookup_companies import _industry
+
+
+class TestIndustryHelper(unittest.TestCase):
+    def make_company(self, industries: str):
+        return Company(
+            organization_name="TestCo",
+            organization_name_url=None,
+            estimated_revenue_range=None,
+            ipo_status=None,
+            operating_status=None,
+            acquisition_status=None,
+            company_type=None,
+            number_of_employees=None,
+            full_description=None,
+            industries=industries,
+            headquarters_location=None,
+            description=None,
+            cb_rank=None,
+        )
+
+    def test_strip_whitespace(self):
+        company = self.make_company("  Software  ")
+        self.assertEqual(_industry(company), "Software")
+
+    def test_remove_urls(self):
+        company = self.make_company("https://example.com")
+        self.assertEqual(_industry(company), "Unknown")
+
+        company2 = self.make_company("Software https://example.com")
+        self.assertEqual(_industry(company2), "Software")
+
+    def test_discard_long_text(self):
+        company = self.make_company("This industry description has many words")
+        self.assertEqual(_industry(company), "Unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- strip whitespace, remove URLs and ignore long text when determining industry
- test URL/whitespace removal and long text handling in `_industry`

## Testing
- `python -m unittest discover -s tests -v`
