### PR TITLE
Normalize industry names

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -14,6 +14,12 @@ import re
 DEFAULT_MAX_LINES = 5
 DEFAULT_MAX_CONCURRENCY = 5
 
+# Mapping of lower-case industry aliases to their canonical names
+_INDUSTRY_ALIASES = {
+    "ai": "Artificial Intelligence",
+    "artificial intelligence (ai)": "Artificial Intelligence",
+}
+
 
 def _employee_count(company: Company) -> Optional[float]:
     """Return an approximate employee count for a company."""
@@ -31,7 +37,10 @@ def _industry(company: Company) -> str:
     if not company.industries:
         return "Unknown"
     parts = re.split(r"[;,]", company.industries)
-    return parts[0].strip() or "Unknown"
+    first = parts[0].strip()
+    if not first:
+        return "Unknown"
+    return _INDUSTRY_ALIASES.get(first.lower(), first)
 
 
 def generate_final_report(companies: List[Company], stances: List[Optional[float]]) -> str:

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -23,7 +23,7 @@ if 'openai' not in sys.modules:
 
 from parser import Company
 from company_lookup import fetch_company_web_info, parse_llm_response
-from lookup_companies import generate_final_report
+from lookup_companies import generate_final_report, _industry
 
 
 class TestFetchCompanyWebInfo(unittest.TestCase):
@@ -177,6 +177,33 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("Average stance per industry", report)
         self.assertIn("Supportive companies tend to be smaller", report)
 
+
+class TestIndustryNormalization(unittest.TestCase):
+    def _make_company(self, industries: str) -> Company:
+        return Company(
+            organization_name="Dummy",
+            organization_name_url=None,
+            estimated_revenue_range=None,
+            ipo_status=None,
+            operating_status=None,
+            acquisition_status=None,
+            company_type=None,
+            number_of_employees=None,
+            full_description=None,
+            industries=industries,
+            headquarters_location=None,
+            description=None,
+            cb_rank=None,
+        )
+
+    def test_aliases_map_to_canonical(self):
+        base = self._make_company("Artificial Intelligence")
+        alias1 = self._make_company("AI")
+        alias2 = self._make_company("Artificial Intelligence (AI)")
+
+        self.assertEqual(_industry(base), "Artificial Intelligence")
+        self.assertEqual(_industry(alias1), "Artificial Intelligence")
+        self.assertEqual(_industry(alias2), "Artificial Intelligence")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add alias mapping in `_industry`
- look up aliases in a case-insensitive way
- test alias handling in `lookup_companies`

## Testing
- `python -m unittest discover -s tests -v`