### PR TITLE
Normalize industry names

### DIFF
--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -23,7 +23,7 @@ if 'openai' not in sys.modules:
 
 from parser import Company
 from company_lookup import fetch_company_web_info, parse_llm_response
-from lookup_companies import generate_final_report
+from lookup_companies import generate_final_report, _industry
 
 
 class TestFetchCompanyWebInfo(unittest.TestCase):
@@ -177,6 +177,33 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("Average stance per industry", report)
         self.assertIn("Supportive companies tend to be smaller", report)
 
+
+class TestIndustryNormalization(unittest.TestCase):
+    def _make_company(self, industries: str) -> Company:
+        return Company(
+            organization_name="Dummy",
+            organization_name_url=None,
+            estimated_revenue_range=None,
+            ipo_status=None,
+            operating_status=None,
+            acquisition_status=None,
+            company_type=None,
+            number_of_employees=None,
+            full_description=None,
+            industries=industries,
+            headquarters_location=None,
+            description=None,
+            cb_rank=None,
+        )
+
+    def test_aliases_map_to_canonical(self):
+        base = self._make_company("Artificial Intelligence")
+        alias1 = self._make_company("AI")
+        alias2 = self._make_company("Artificial Intelligence (AI)")
+
+        self.assertEqual(_industry(base), "Artificial Intelligence")
+        self.assertEqual(_industry(alias1), "Artificial Intelligence")
+        self.assertEqual(_industry(alias2), "Artificial Intelligence")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lookup_companies.py
+++ b/tests/test_lookup_companies.py
@@ -1,0 +1,41 @@
+import unittest
+from parser import Company
+from lookup_companies import _industry
+
+
+class TestIndustryHelper(unittest.TestCase):
+    def make_company(self, industries: str):
+        return Company(
+            organization_name="TestCo",
+            organization_name_url=None,
+            estimated_revenue_range=None,
+            ipo_status=None,
+            operating_status=None,
+            acquisition_status=None,
+            company_type=None,
+            number_of_employees=None,
+            full_description=None,
+            industries=industries,
+            headquarters_location=None,
+            description=None,
+            cb_rank=None,
+        )
+
+    def test_strip_whitespace(self):
+        company = self.make_company("  Software  ")
+        self.assertEqual(_industry(company), "Software")
+
+    def test_remove_urls(self):
+        company = self.make_company("https://example.com")
+        self.assertEqual(_industry(company), "Unknown")
+
+        company2 = self.make_company("Software https://example.com")
+        self.assertEqual(_industry(company2), "Software")
+
+    def test_discard_long_text(self):
+        company = self.make_company("This industry description has many words")
+        self.assertEqual(_industry(company), "Unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add alias mapping in `_industry`
- sanitize industry names to filter out URLs or long strings
- add dedicated tests for industry sanitization
- test alias handling in `lookup_companies`

## Testing
- `python -m unittest discover -s tests -v`
