### PR TITLE
Add explicit JSON output instruction to prompts

### DIFF
--- a/company_lookup.py
+++ b/company_lookup.py
@@ -64,7 +64,8 @@ def fetch_company_web_info(
         "For example:\n"
         "```json\n{\"supportive\": 0.8}\n``` "
         "Mozilla and the Electronic Frontier Foundation would be close to 1, "
-        "while Meta and Palantir might be near 0."
+        "while Meta and Palantir might be near 0. "
+        "Finish with ONLY the JSON block on a new line."
 
     )
 
@@ -136,7 +137,8 @@ async def async_fetch_company_web_info(
         "For example:\n"
         "```json\n{\"supportive\": 0.8}\n``` "
         "Mozilla and the Electronic Frontier Foundation would be close to 1, "
-        "while Meta and Palantir might be near 0."
+        "while Meta and Palantir might be near 0. "
+        "Finish with ONLY the JSON block on a new line."
     )
 
     response = await client.chat.completions.create(

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -66,6 +66,10 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
                     self.assertIn("key 'supportive'", user_content)
                     self.assertIn("scale from 0 (strong opponent) to 1 (strong proponent)", user_content)
                     self.assertIn("Mozilla", user_content)
+                    self.assertIn(
+                        "Finish with ONLY the JSON block on a new line",
+                        user_content,
+                    )
 
     def test_parse_llm_response(self):
         text = (


### PR DESCRIPTION
## Summary
- ensure `fetch_company_web_info` and its async variant instruct the model to finish with only the JSON block
- update unit tests to check for the new guidance in the prompt

## Testing
- `python -m unittest discover -s tests -v`