### PR TITLE
Enhance LLM response parsing

### DIFF
--- a/company_lookup.py
+++ b/company_lookup.py
@@ -165,12 +165,13 @@ def parse_llm_response(response: str) -> Optional[float]:
     if not response:
         return None
 
-    match = re.search(r"```json\s*(\{.*?\})\s*```", response, re.DOTALL)
+    match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", response, re.IGNORECASE | re.DOTALL)
     if not match:
         return None
 
     try:
-        data = json.loads(match.group(1))
+        json_text = match.group(1).replace("'", '"')
+        data = json.loads(json_text)
     except json.JSONDecodeError:
         return None
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -96,6 +96,28 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         text_out_of_range = "```json\n{\"supportive\": 1.5}\n```"
         self.assertIsNone(parse_llm_response(text_out_of_range))
 
+    def test_parse_llm_response_no_label(self):
+        text = (
+            "Intro.\n"
+            "```\n"
+            '{"supportive": 0.6}'
+            "\n```"
+        )
+        result = parse_llm_response(text)
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result, 0.6)
+
+    def test_parse_llm_response_single_quotes(self):
+        text = (
+            "Intro.\n"
+            "```json\n"
+            "{'supportive': '0.3'}"
+            "\n```"
+        )
+        result = parse_llm_response(text)
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result, 0.3)
+
     @patch('company_lookup.openai.OpenAI')
     def test_cache_reused_for_same_seed(self, mock_openai):
         mock_client = mock_openai.return_value


### PR DESCRIPTION
## Summary
- accept non-labeled JSON blocks in `parse_llm_response`
- normalize single quotes before JSON parsing
- add tests for new parsing scenarios

## Testing
- `python -m unittest discover -s tests -v`