### PR TITLE
Enable async cache

### DIFF
--- a/tests/test_lookup_companies.py
+++ b/tests/test_lookup_companies.py
@@ -1,4 +1,21 @@
 import unittest
+import sys
+import types
+
+if 'openai' not in sys.modules:
+    def make_client(*args, **kwargs):
+        return types.SimpleNamespace(
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=lambda **kwargs: None)
+            )
+        )
+
+    openai_stub = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=lambda **kwargs: None),
+        OpenAI=make_client,
+    )
+    sys.modules['openai'] = openai_stub
+
 from parser import Company
 from lookup_companies import _industry
 


### PR DESCRIPTION
## Summary
- support caching in `async_fetch_company_web_info`
- test that async helper reuses cache
- stub `openai` in lookup helper tests so they run without the real package

## Testing
- `PYTHONPATH=. python -m unittest tests.test_company_lookup tests.test_lookup_companies tests.test_parser -v`