### PR TITLE
Update CLI output to show only final report

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ control the level of concurrency with the `--max-concurrency` flag (default is 5
 python lookup_companies.py path/to/companies.csv --max-lines 5 --max-concurrency 10
 ```
 
-This will print summaries for the first few companies in the spreadsheet.
+This will fetch summaries and then display only the final report. The output
+also notes how many responses were retrieved from the local cache.
 
 ## Report Generation
 

--- a/company_lookup.py
+++ b/company_lookup.py
@@ -2,7 +2,7 @@ import os
 import hashlib
 from dataclasses import asdict
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 import json
 import re
 
@@ -16,7 +16,8 @@ def fetch_company_web_info(
     model: Optional[str] = None,
     *,
     seed: Optional[int] = None,
-) -> Optional[str]:
+    return_cache_info: bool = False,
+) -> Union[Optional[str], Tuple[Optional[str], bool]]:
     """Ask an LLM to search the web for company information.
 
     This stub assumes the model can perform web searches. It sends a prompt to
@@ -76,7 +77,8 @@ def fetch_company_web_info(
     ).hexdigest()
     cache_file = cache_dir / f"{cache_key}.txt"
     if cache_file.exists():
-        return cache_file.read_text(encoding="utf-8")
+        content = cache_file.read_text(encoding="utf-8")
+        return (content, True) if return_cache_info else content
 
     response = client.chat.completions.create(
         model=model_name,
@@ -101,7 +103,7 @@ def fetch_company_web_info(
 
     if content is not None:
         cache_file.write_text(content, encoding="utf-8")
-    return content
+    return (content, False) if return_cache_info else content
 
 
 async def async_fetch_company_web_info(
@@ -109,7 +111,8 @@ async def async_fetch_company_web_info(
     model: Optional[str] = None,
     *,
     seed: Optional[int] = None,
-) -> Optional[str]:
+    return_cache_info: bool = False,
+) -> Union[Optional[str], Tuple[Optional[str], bool]]:
     """Asynchronously fetch company info using OpenAI.
 
     This mirrors :func:`fetch_company_web_info` but operates asynchronously and
@@ -163,7 +166,8 @@ async def async_fetch_company_web_info(
     ).hexdigest()
     cache_file = cache_dir / f"{cache_key}.txt"
     if cache_file.exists():
-        return cache_file.read_text(encoding="utf-8")
+        content = cache_file.read_text(encoding="utf-8")
+        return (content, True) if return_cache_info else content
 
     response = await client.chat.completions.create(
         model=model_name,
@@ -188,7 +192,7 @@ async def async_fetch_company_web_info(
 
     if content is not None:
         cache_file.write_text(content, encoding="utf-8")
-    return content
+    return (content, False) if return_cache_info else content
 
 
 def parse_llm_response(response: str) -> Optional[float]:

--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -181,29 +181,34 @@ async def _run_async(companies, max_concurrency: int) -> None:
     semaphore = asyncio.Semaphore(max_concurrency)
 
     stances: List[Optional[float]] = []
+    cached_count = 0
 
     async def fetch(company):
         async with semaphore:
-            return await async_fetch_company_web_info(company.organization_name)
+            return await async_fetch_company_web_info(
+                company.organization_name,
+                return_cache_info=True,
+            )
 
     tasks = [asyncio.create_task(fetch(c)) for c in companies]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    for idx, result in enumerate(results, start=1):
-        company = companies[idx - 1]
-        print(f"\n[{idx}/{len(companies)}] Result for: {company.organization_name}")
+    for result in results:
         if isinstance(result, Exception):
-            print(f"Error fetching info for {company.organization_name}: {result}")
             stances.append(None)
-        elif result:
-            print(result)
-            stances.append(parse_llm_response(result))
+            continue
+
+        content, cached = result
+        if cached:
+            cached_count += 1
+        if content:
+            stances.append(parse_llm_response(content))
         else:
-            print("No summary returned.")
             stances.append(None)
 
     report = generate_final_report(companies, stances)
-    print("\n" + report)
+    print(report)
+    print(f"Cached responses used: {cached_count}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- revise README usage notes to mention final report and cache info
- extend lookup helpers to indicate when results are cached
- change CLI to skip per-company output and print cached count

## Testing
- `python -m unittest discover -s tests -v`