### PR TITLE
Add malformed CSV tests

### DIFF
--- a/tests/data/companies_malformed_encoding.csv
+++ b/tests/data/companies_malformed_encoding.csv
@@ -1,0 +1,2 @@
+Organization Name,Organization Name URL,Estimated Revenue Range,IPO Status,Operating Status,Acquisition Status,Company Type,Number of Employees,Full Description,Industries,Headquarters Location,Description,CB Rank (Company)
+Caf√© Corp,https://cafe.example.com,$10M-$50M,Private,Operating,,For Profit,100-250,"A cafe with misencoded name.",Hospitality,"Montr√©al, Quebec, Canada",A misencoded line,1

--- a/tests/data/companies_malformed_extra_column.csv
+++ b/tests/data/companies_malformed_extra_column.csv
@@ -1,0 +1,3 @@
+Organization Name,Organization Name URL,Estimated Revenue Range,IPO Status,Operating Status,Acquisition Status,Company Type,Number of Employees,Full Description,Industries,Headquarters Location,Description,CB Rank (Company)
+Acme Corp,https://acme.example.com,$10M-$50M,Private,Operating,,For Profit,100-250,Acme Corp specializes in gadgets and gizmos.,Manufacturing,"New York, NY",Leading gadget manufacturer,1,EXTRA
+Globex Inc,https://globex.example.com,$50M-$100M,Public,Operating,,For Profit,500-1000,Globex provides a variety of high-tech solutions.,Technology,"San Francisco, CA",Innovative tech company,2,EXTRA

--- a/tests/data/companies_malformed_quote.csv
+++ b/tests/data/companies_malformed_quote.csv
@@ -1,0 +1,2 @@
+Organization Name,Organization Name URL,Estimated Revenue Range,IPO Status,Operating Status,Acquisition Status,Company Type,Number of Employees,Full Description,Industries,Headquarters Location,Description,CB Rank (Company)
+"Broken Co,https://broken.example.com,$10M-$50M,Private,Operating,,For Profit,100-250,"This quote never ends,Manufacturing,"New York, NY",Bad row,1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,24 @@ class TestReadCompaniesFromCSV(unittest.TestCase):
         self.assertEqual(len(companies), 3)
         self.assertIsNone(companies[0].full_description)
 
+    def test_extra_column_ignored(self):
+        path = pathlib.Path(__file__).parent / "data" / "companies_malformed_extra_column.csv"
+        companies = read_companies_from_csv(path)
+        self.assertEqual(len(companies), 2)
+        self.assertEqual(companies[0].organization_name, "Acme Corp")
+
+    def test_unbalanced_quote(self):
+        path = pathlib.Path(__file__).parent / "data" / "companies_malformed_quote.csv"
+        companies = read_companies_from_csv(path)
+        self.assertEqual(len(companies), 1)
+        self.assertTrue(companies[0].organization_name.startswith("Broken Co"))
+
+    def test_misencoded_text(self):
+        path = pathlib.Path(__file__).parent / "data" / "companies_malformed_encoding.csv"
+        companies = read_companies_from_csv(path)
+        self.assertEqual(len(companies), 1)
+        self.assertIn("√", companies[0].organization_name)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add sample CSVs with malformed rows and encoding issues
- add parser tests for unbalanced quotes, extra columns, and misencoded text

## Testing
- `python -m unittest discover -s tests -p "test_*.py"`