### PR TITLE
Add dataset summary statistics to final report

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ the text report (`final_report.txt`) should be saved.
 The lookup script finishes by producing a **final report** summarizing stance
 coverage for each industry. The report now includes basic statistics such as the
 number of supportive companies per industry, average stance values and a simple
-ASCII bar chart. The text report is written to ``final_report.txt`` alongside a
+ASCII bar chart. It also lists common categories found in the input data and
+provides a short summary of numeric value distributions. The text report is written to ``final_report.txt`` alongside a
 CSV table of company summaries. When the optional ``scipy`` package is
 installed, a t-test is performed to compare employee counts of supportive vs.
 non-supportive companies.
@@ -98,6 +99,10 @@ Supportive companies by industry:
 Average stance per industry:
   Manufacturing: 0.80
   Technology: 0.40
+Input data statistics:
+Most common industry: Manufacturing (1)
+Most common IPO status: Unknown (3)
+Employee counts (min/median/max): 75 / 175 / 750
 ```
 
 ## Running Tests

--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -98,8 +98,8 @@ def generate_final_report(companies: List[Company], stances: List[Optional[float
     numbers indicate stronger support for interoperability legislation.
     """
 
-    from collections import defaultdict
-    from statistics import mean
+    from collections import defaultdict, Counter
+    from statistics import mean, median
 
     try:
         from scipy.stats import ttest_ind
@@ -175,6 +175,24 @@ def generate_final_report(companies: List[Company], stances: List[Optional[float
             lines.append("Not enough data for t-test of company size.")
     else:
         lines.append("Insufficient data to compare company sizes.")
+
+    industries_all = [_industry(c) for c in companies]
+    ipo_statuses = [c.ipo_status or "Unknown" for c in companies]
+    emp_values = [
+        e for c in companies if (e := _employee_count(c)) is not None
+    ]
+
+    lines.append("\nInput data statistics:")
+    if industries_all:
+        ind_name, ind_count = Counter(industries_all).most_common(1)[0]
+        lines.append(f"Most common industry: {ind_name} ({ind_count})")
+    if ipo_statuses:
+        ipo_name, ipo_count = Counter(ipo_statuses).most_common(1)[0]
+        lines.append(f"Most common IPO status: {ipo_name} ({ipo_count})")
+    if emp_values:
+        lines.append(
+            f"Employee counts (min/median/max): {int(min(emp_values))} / {int(median(emp_values))} / {int(max(emp_values))}"
+        )
 
     return "\n".join(lines)
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -239,6 +239,10 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("  Technology:  (0/1)", report)
         self.assertIn("Average stance per industry", report)
         self.assertIn("Supportive companies tend to be smaller", report)
+        self.assertIn("Input data statistics", report)
+        self.assertIn("Most common industry: Manufacturing (1)", report)
+        self.assertIn("Most common IPO status: Unknown (3)", report)
+        self.assertIn("Employee counts (min/median/max): 75 / 175 / 750", report)
 
 
 class TestIndustryNormalization(unittest.TestCase):


### PR DESCRIPTION
## Summary
- update README with example of new data stats in the report
- extend `generate_final_report` to compute most common categories and employee-count distribution
- test the new report information

## Testing
- `python -m unittest discover -s tests -v`