### PR TITLE
Handle apostrophes in LLM JSON

### DIFF
--- a/company_lookup.py
+++ b/company_lookup.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional, Union, Tuple
 import json
 import re
+import ast
 
 from parser import Company
 
@@ -228,11 +229,16 @@ def parse_llm_response(response: str) -> Optional[dict]:
     if not match:
         return None
 
+    json_text = match.group(1).strip()
     try:
-        json_text = match.group(1).replace("'", '"')
         data = json.loads(json_text)
     except json.JSONDecodeError:
-        return None
+        try:
+            data = ast.literal_eval(json_text)
+        except Exception:
+            return None
+        if not isinstance(data, dict):
+            return None
 
     supportive = _parse_support_value(data.get("supportive"))
     data["supportive"] = supportive

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -132,6 +132,19 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertAlmostEqual(result.get("supportive"), 0.3)
 
+    def test_parse_llm_response_embedded_apostrophes(self):
+        text = (
+            "Intro.\n"
+            "```json\n"
+            '{"organization_name": "O\'Reilly", "supportive": 0.6}'
+            "\n```"
+        )
+        result = parse_llm_response(text)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get("organization_name"), "O'Reilly")
+        self.assertAlmostEqual(result.get("supportive"), 0.6)
+
     @patch('company_lookup.openai.OpenAI')
     def test_cache_reused_for_same_seed(self, mock_openai):
         mock_client = mock_openai.return_value


### PR DESCRIPTION
## Summary
- improve `parse_llm_response` parsing
  - try `json.loads` first and fall back to `ast.literal_eval`
  - avoid blind replacement of quotes
- test JSON with embedded apostrophes

## Testing
- `python -m unittest discover -s tests -v`