### PR TITLE
Add extra company metrics to final report

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ the text report (`final_report.txt`) should be saved.
 ## Report Generation
 
 The lookup script finishes by producing a **final report** summarizing stance
-coverage for each industry. The report now includes basic statistics such as the
-number of supportive companies per industry, average stance values and a simple
-ASCII bar chart. The text report is written to ``final_report.txt`` alongside a
-CSV table of company summaries. When the optional ``scipy`` package is
-installed, a t-test is performed to compare employee counts of supportive vs.
-non-supportive companies.
+coverage for each industry. The report now includes additional breakdowns such
+as support by IPO status, revenue range and CB rank, along with a simple company
+size metric that combines these factors. Basic statistics such as the number of
+supportive companies per industry, average stance values and an ASCII bar chart
+are shown. The text report is written to ``final_report.txt`` alongside a CSV
+table of company summaries. When the optional ``scipy`` package is installed,
+a t-test is performed to compare employee counts of supportive vs. non-supportive
+companies.
 
 Example snippet:
 
@@ -98,6 +100,13 @@ Supportive companies by industry:
 Average stance per industry:
   Manufacturing: 0.80
   Technology: 0.40
+
+Support by IPO status:
+  Pre-IPO: 2/3
+Support by revenue:
+  Unknown: 2/3
+Support by CB rank:
+  Unknown: 2/3
 ```
 
 ## Running Tests

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -238,7 +238,12 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("  Software: ########## (1/1)", report)
         self.assertIn("  Technology:  (0/1)", report)
         self.assertIn("Average stance per industry", report)
-        self.assertIn("Supportive companies tend to be smaller", report)
+        self.assertIn("Support by IPO status", report)
+        self.assertIn("Pre-IPO: 2/3", report)
+        self.assertIn("Support by revenue", report)
+        self.assertIn("Support by CB rank", report)
+        self.assertIn("Supportive companies tend to be smaller based on employee counts.", report)
+        self.assertIn("Supportive companies appear smaller based on combined size metric.", report)
 
 
 class TestIndustryNormalization(unittest.TestCase):


### PR DESCRIPTION
## Summary
- enrich final report with statistics by IPO status, revenue and CB rank
- introduce company size metric
- document new metrics in README
- update tests for enhanced report

## Testing
- `python -m unittest discover -s tests -v`