### PR TITLE
Add AI sub-category support

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -160,7 +160,11 @@ def _industry(company: Company) -> str:
 
     return "Unknown"
 
-def generate_final_report(companies: List[Company], stances: List[Optional[float]]) -> str:
+def generate_final_report(
+    companies: List[Company],
+    stances: List[Optional[float]],
+    subcategories: Optional[List[Optional[str]]] = None,
+) -> str:
     """Generate a more detailed summary of stance coverage per industry.
 
     ``stances`` should contain numeric values between 0 and 1 where higher
@@ -176,6 +180,7 @@ def generate_final_report(companies: List[Company], stances: List[Optional[float
         ttest_ind = None
 
     industry_data = defaultdict(lambda: {"supportive": 0, "total": 0, "stances": []})
+    subcat_data = defaultdict(lambda: {"supportive": 0, "total": 0})
     ipo_data = defaultdict(lambda: {"supportive": 0, "total": 0})
     revenue_data = defaultdict(lambda: {"supportive": 0, "total": 0})
     rank_data = defaultdict(lambda: {"supportive": 0, "total": 0})
@@ -186,12 +191,19 @@ def generate_final_report(companies: List[Company], stances: List[Optional[float
     support_emp: List[float] = []
     nonsupport_emp: List[float] = []
 
-    for company, stance in zip(companies, stances):
+    sub_iter = subcategories if subcategories is not None else [None] * len(companies)
+    for company, stance, subcat in zip(companies, stances, sub_iter):
         ind = _industry(company)
         info = industry_data[ind]
         info["total"] += 1
         if stance is not None:
             info["stances"].append(stance)
+
+        sc = subcat or "Uncategorized"
+        sc_info = subcat_data[sc]
+        sc_info["total"] += 1
+        if stance is not None and stance >= 0.5:
+            sc_info["supportive"] += 1
 
         ipo_cat = _ipo_category(company.ipo_status)
         ipo_info = ipo_data[ipo_cat]
@@ -263,6 +275,11 @@ def generate_final_report(companies: List[Company], stances: List[Optional[float
             lines.append(f"  {ind}: {mean(st_list):.2f}")
         else:
             lines.append(f"  {ind}: n/a")
+
+    lines.append("\nSupport by AI sub-category:")
+    for cat in sorted(subcat_data):
+        d = subcat_data[cat]
+        lines.append(f"  {cat}: {d['supportive']}/{d['total']} supportive")
 
     if support_emp and (support_emp or nonsupport_emp):
         avg_support_size = mean(support_emp)
@@ -389,6 +406,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
     semaphore = asyncio.Semaphore(max_concurrency)
 
     stances: List[Optional[float]] = []
+    subcats: List[Optional[str]] = []
     cached_count = 0
     table_rows: List[List[str]] = []
 
@@ -405,6 +423,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
     for company, result in zip(companies, results):
         if isinstance(result, Exception):
             stances.append(None)
+            subcats.append(None)
             table_rows.append([
                 company.organization_name,
                 _industry(company),
@@ -424,10 +443,13 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                 if parsed is None:
                     stance_val = None
                     justification = None
+                    subcat = None
                 else:
                     stance_val = parsed.get("supportive")
                     justification = parsed.get("justification")
+                    subcat = parsed.get("sub_category")
                 stances.append(stance_val)
+                subcats.append(subcat)
                 summary_text = re.split(r"```(?:json)?\s*\{.*?\}\s*```", content, flags=re.DOTALL)[0].strip()
                 if stance_val is None:
                     stance_label = "Unknown"
@@ -438,6 +460,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                 table_rows.append([
                     company.organization_name,
                     _industry(company),
+                    subcat or "",
                     summary_text,
                     stance_label,
                     justification or summary_text,
@@ -445,9 +468,11 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                 ])
             else:
                 stances.append(None)
+                subcats.append(None)
                 table_rows.append([
                     company.organization_name,
                     _industry(company),
+                    "",
                     "",
                     "Unknown",
                     "",
@@ -456,16 +481,18 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
 
         else:
             stances.append(None)
+            subcats.append(None)
             table_rows.append([
                 company.organization_name,
                 _industry(company),
+                "",
                 "",
                 "Unknown",
                 "",
                 "",
             ])
 
-    report = generate_final_report(companies, stances)
+    report = generate_final_report(companies, stances, subcats)
     print(report)
     print(f"Cached responses used: {cached_count}")
 
@@ -477,6 +504,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
             [
                 "Company Name",
                 "Industry",
+                "AI Sub-Category",
                 "Business Model Summary",
                 "Likely Stance on Interoperability",
                 "Qualitative Justification",

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -75,12 +75,13 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
                     self.assertIn("Palantir", user_content)
                     self.assertIn("Return ONLY a JSON code block", user_content)
                     self.assertIn("```json", user_content)
+                    self.assertIn("sub_category", user_content)
 
     def test_parse_llm_response(self):
         text = (
             "Acme summary.\n"
             "```json\n"
-            '{"organization_name": "Acme", "supportive": 0.75}'
+            '{"organization_name": "Acme", "supportive": 0.75, "sub_category": "Generative AI"}'
             "\n```"
         )
         result = parse_llm_response(text)
@@ -88,6 +89,7 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertAlmostEqual(result.get("supportive"), 0.75)
         self.assertEqual(result.get("organization_name"), "Acme")
+        self.assertEqual(result.get("sub_category"), "Generative AI")
 
     def test_parse_llm_response_edge_cases(self):
         self.assertIsNone(parse_llm_response("nonsense"))
@@ -356,8 +358,8 @@ class TestRunAsync(unittest.TestCase):
         self.assertEqual(rows[0][0], "Company Name")
         acme = rows[1]
         globex = rows[2]
-        self.assertNotEqual(acme[2], acme[4])
-        self.assertEqual(globex[2], globex[4])
+        self.assertNotEqual(acme[3], acme[5])
+        self.assertEqual(globex[3], globex[5])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add AI sub-category taxonomy and request it in the LLM prompt
- parse `sub_category` from model output
- break down the final report by AI sub-category and export it in the table
- update unit tests for new field

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*