### PR TITLE
Add top supportive companies to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ ASCII bar chart. It also lists common categories found in the input data and
 provides a short summary of numeric value distributions. Support levels are
 broken down by IPO status, revenue range and CB rank, and the output includes a
 simple company size metric that combines employee counts with these fields. The
+report lists the top three most supportive companies for each AI sub-category.
 text report is written to ``final_report.txt`` alongside a
 CSV table of company summaries. When the optional ``scipy`` package is
 installed, statistical tests are included in the report. T-tests compare

--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -182,6 +182,7 @@ def generate_final_report(
 
     industry_data = defaultdict(lambda: {"supportive": 0, "total": 0, "stances": []})
     subcat_data = defaultdict(lambda: {"supportive": 0, "total": 0})
+    subcat_top = defaultdict(list)
     ipo_data = defaultdict(lambda: {"supportive": 0, "total": 0})
     revenue_data = defaultdict(lambda: {"supportive": 0, "total": 0})
     rank_data = defaultdict(lambda: {"supportive": 0, "total": 0})
@@ -203,8 +204,10 @@ def generate_final_report(
         sc = subcat or "Uncategorized"
         sc_info = subcat_data[sc]
         sc_info["total"] += 1
-        if stance is not None and stance >= 0.5:
-            sc_info["supportive"] += 1
+        if stance is not None:
+            subcat_top[sc].append((stance, company.organization_name))
+            if stance >= 0.5:
+                sc_info["supportive"] += 1
 
         ipo_cat = _ipo_category(company.ipo_status)
         ipo_info = ipo_data[ipo_cat]
@@ -281,6 +284,14 @@ def generate_final_report(
     for cat in sorted(subcat_data):
         d = subcat_data[cat]
         lines.append(f"  {cat}: {d['supportive']}/{d['total']} supportive")
+        top = sorted(
+            (pair for pair in subcat_top.get(cat, []) if pair[0] is not None),
+            key=lambda x: x[0],
+            reverse=True,
+        )[:3]
+        if top:
+            names = ", ".join(name for _, name in top)
+            lines.append(f"    Top companies: {names}")
 
     if support_emp and (support_emp or nonsupport_emp):
         avg_support_size = mean(support_emp)

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -260,6 +260,7 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("  Software: ########## (1/1)", report)
         self.assertIn("  Technology:  (0/1)", report)
         self.assertIn("Average stance per industry", report)
+        self.assertIn("Top companies: Initech, Acme Corp, Globex Inc", report)
         self.assertIn("Supportive companies tend to be smaller", report)
         self.assertIn("Support by IPO status", report)
         self.assertIn("Support by revenue range", report)


### PR DESCRIPTION
## Summary
- list the top three supportive companies for each AI sub-category in the final report
- document the new report feature in README
- test that `generate_final_report` includes the new section

## Testing
- `python -m unittest discover -s tests -v`