### PR TITLE
Add justification examples to final report

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -31,6 +31,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
 
     stances: List[Optional[float]] = []
     subcats: List[Optional[str]] = []
+    just_list: List[Optional[str]] = []
     cached_count = 0
     table_rows: List[List[str]] = []
 
@@ -48,6 +49,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
         if isinstance(result, Exception):
             stances.append(None)
             subcats.append(None)
+            just_list.append(None)
             table_rows.append(
                 [
                     company.organization_name,
@@ -84,6 +86,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
 
                 stances.append(stance_val)
                 subcats.append(subcat)
+                just_list.append(justification)
 
                 summary_text = re.split(
                     r"```(?:json)?\s*\{.*?\}\s*```", content, flags=re.DOTALL
@@ -112,6 +115,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
             else:
                 stances.append(None)
                 subcats.append(None)
+                just_list.append(None)
                 table_rows.append(
                     [
                         company.organization_name,
@@ -127,6 +131,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
         else:
             stances.append(None)
             subcats.append(None)
+            just_list.append(None)
             table_rows.append(
                 [
                     company.organization_name,
@@ -139,7 +144,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                 ]
             )
 
-    report = generate_final_report(companies, stances, subcats)
+    report = generate_final_report(companies, stances, subcats, just_list)
     print(report)
     print(f"Cached responses used: {cached_count}")
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -251,7 +251,12 @@ class TestFinalReport(unittest.TestCase):
         ]
 
         stances = [0.8, 0.4, 0.9]
-        report = generate_final_report(companies, stances)
+        justifications = [
+            "Because open standards are good",
+            "Less interested in openness",
+            "Strong advocate for open APIs",
+        ]
+        report = generate_final_report(companies, stances, justifications=justifications)
         self.assertIn("Manufacturing: supportive company found", report)
         self.assertIn("Technology: no supportive company found", report)
         self.assertIn("Software: supportive company found", report)
@@ -272,6 +277,8 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("Most common IPO status: Unknown (3)", report)
         self.assertIn("Employee counts (min/median/max): 75 / 175 / 750", report)
         self.assertIn("Conclusions:", report)
+        self.assertIn("Example justifications:", report)
+        self.assertIn("Acme Corp (Support): Because open standards are good", report)
 
 
 class TestIndustryNormalization(unittest.TestCase):


### PR DESCRIPTION
## Summary
- include justification examples in `generate_final_report`
- carry justification data through async helper functions
- adjust tests for new report output

## Testing
- `python -m unittest discover -s tests -v`