### PR TITLE
Filter non-business entries from CSV

### DIFF
--- a/tests/data/companies_non_business.csv
+++ b/tests/data/companies_non_business.csv
@@ -1,0 +1,4 @@
+Organization Name,Organization Name URL,Estimated Revenue Range,IPO Status,Operating Status,Acquisition Status,Company Type,Number of Employees,Full Description,Industries,Headquarters Location,Description,CB Rank (Company)
+Acme Corp,https://acme.example.com,$10M-$50M,Private,Operating,,For Profit,100-250,Acme makes gadgets,Manufacturing,"New York, NY",Leading gadget manufacturer,1
+Vector Institute,https://vector.example.com,$1B-$5B,Private,Operating,,For Profit,101-250,"Vector is a research institute",Artificial Intelligence,"Toronto, Canada",AI research lab,2
+Globex Inc,https://globex.example.com,$50M-$100M,Public,Operating,,For Profit,500-1000,Globex provides solutions,Technology,"San Francisco, CA",Innovative tech company,3

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -79,16 +79,17 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
                     )
                     self.assertIn("Mozilla", user_content)
                     self.assertIn("Palantir", user_content)
-                    self.assertIn("Return ONLY a JSON code block", user_content)
-                    self.assertIn("```json", user_content)
-                    self.assertIn("sub_category", user_content)
-                    self.assertIn("justification", user_content)
+        self.assertIn("Return ONLY a JSON code block", user_content)
+        self.assertIn("```json", user_content)
+        self.assertIn("sub_category", user_content)
+        self.assertIn("justification", user_content)
+        self.assertIn("is_business", user_content)
 
     def test_parse_llm_response(self):
         text = (
             "Acme summary.\n"
             "```json\n"
-            '{"organization_name": "Acme", "supportive": 0.75, "sub_category": "Generative AI"}'
+            '{"organization_name": "Acme", "supportive": 0.75, "sub_category": "Generative AI", "is_business": true}'
             "\n```"
         )
         result = parse_llm_response(text)
@@ -97,6 +98,7 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertAlmostEqual(result.get("supportive"), 0.75)
         self.assertEqual(result.get("organization_name"), "Acme")
         self.assertEqual(result.get("sub_category"), "Generative AI")
+        self.assertTrue(result.get("is_business"))
 
     def test_parse_llm_response_edge_cases(self):
         self.assertIsNone(parse_llm_response("nonsense"))
@@ -117,6 +119,12 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         result = parse_llm_response(text_out_of_range)
         self.assertIsNotNone(result)
         self.assertIsNone(result.get("supportive"))
+
+        bool_yes = '```json\n{"is_business": "yes"}\n```'
+        self.assertTrue(parse_llm_response(bool_yes)["is_business"])
+
+        bool_no = '```json\n{"is_business": "no"}\n```'
+        self.assertFalse(parse_llm_response(bool_no)["is_business"])
 
     def test_parse_llm_response_no_label(self):
         text = "Intro.\n" "```\n" '{"supportive": 0.6}' "\n```"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -61,6 +61,12 @@ class TestReadCompaniesFromCSV(unittest.TestCase):
         self.assertEqual(len(companies), 1)
         self.assertIn("√", companies[0].organization_name)
 
+    def test_excludes_non_business(self):
+        path = pathlib.Path(__file__).parent / "data" / "companies_non_business.csv"
+        companies = read_companies_from_csv(path)
+        names = [c.organization_name for c in companies]
+        self.assertEqual(names, ["Acme Corp", "Globex Inc"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- skip organizations that don't appear to be businesses when reading CSV files
- add regression test for this filtering logic
- add LLM classification for legit businesses vs other organizations

## Testing
- `python -m unittest discover -s tests -v`