### PR TITLE
Filter non-businesses in generated reports

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -32,6 +32,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
     stances: List[Optional[float]] = []
     subcats: List[Optional[str]] = []
     just_list: List[Optional[str]] = []
+    biz_list: List[Optional[bool]] = []
     cached_count = 0
     table_rows: List[List[str]] = []
 
@@ -74,6 +75,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                     justification = None
                     subcat = None
                     parsed_summary = None
+                    is_biz = None
                 else:
                     stance_val = parsed.get("supportive")
                     justification = parsed.get("justification")
@@ -83,10 +85,12 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                         or parsed.get("business_model")
                         or parsed.get("summary")
                     )
+                    is_biz = parsed.get("is_business")
 
                 stances.append(stance_val)
                 subcats.append(subcat)
                 just_list.append(justification)
+                biz_list.append(is_biz)
 
                 summary_text = re.split(
                     r"```(?:json)?\s*\{.*?\}\s*```", content, flags=re.DOTALL
@@ -116,6 +120,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                 stances.append(None)
                 subcats.append(None)
                 just_list.append(None)
+                biz_list.append(None)
                 table_rows.append(
                     [
                         company.organization_name,
@@ -132,6 +137,7 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
             stances.append(None)
             subcats.append(None)
             just_list.append(None)
+            biz_list.append(None)
             table_rows.append(
                 [
                     company.organization_name,
@@ -144,7 +150,13 @@ async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
                 ]
             )
 
-    report = generate_final_report(companies, stances, subcats, just_list)
+    report = generate_final_report(
+        companies,
+        stances,
+        subcats,
+        just_list,
+        biz_list,
+    )
     print(report)
     print(f"Cached responses used: {cached_count}")
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -288,6 +288,55 @@ class TestFinalReport(unittest.TestCase):
         self.assertIn("Example justifications:", report)
         self.assertIn("Acme Corp (Support): Because open standards are good", report)
 
+    def test_excludes_non_business(self):
+        companies = [
+            Company(
+                organization_name="Acme Corp",
+                organization_name_url=None,
+                estimated_revenue_range=None,
+                ipo_status=None,
+                operating_status=None,
+                acquisition_status=None,
+                company_type=None,
+                number_of_employees="100-250",
+                full_description=None,
+                industries="Manufacturing",
+                headquarters_location=None,
+                description=None,
+                cb_rank=None,
+            ),
+            Company(
+                organization_name="Globex Institute",
+                organization_name_url=None,
+                estimated_revenue_range=None,
+                ipo_status=None,
+                operating_status=None,
+                acquisition_status=None,
+                company_type=None,
+                number_of_employees="500-1000",
+                full_description=None,
+                industries="Technology",
+                headquarters_location=None,
+                description=None,
+                cb_rank=None,
+            ),
+        ]
+
+        stances = [0.8, 0.4]
+        justifications = [
+            "Because open standards are good",
+            "Less interested in openness",
+        ]
+        is_biz = [True, False]
+        report = generate_final_report(
+            companies,
+            stances,
+            justifications=justifications,
+            is_business_flags=is_biz,
+        )
+        self.assertIn("Overall 1/1 companies are supportive", report)
+        self.assertNotIn("Globex Institute", report)
+
 
 class TestIndustryNormalization(unittest.TestCase):
     def _make_company(self, industries: str) -> Company:


### PR DESCRIPTION
## Summary
- add `is_business_flags` parameter to `generate_final_report`
- filter entries in report and examples that are marked as non-businesses
- record business flag when fetching company info
- propagate business flag through lookup pipeline
- test exclusion of non-businesses

## Testing
- `python -m unittest discover -s tests -v`