### PR TITLE
Add quality checks for duplicates and missing fields

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -14,6 +14,7 @@ from spreadsheet_parser import (
     parse_llm_response,
 )
 from spreadsheet_parser.csv_reader import read_companies_from_csv
+from spreadsheet_parser.quality import find_duplicate_names, rows_with_missing_fields
 
 __all__ = [
     "run_async",
@@ -25,6 +26,7 @@ __all__ = [
     "_industry",
     "main",
 ]
+
 
 async def _run_async(companies, max_concurrency: int, output_dir: Path) -> None:
     semaphore = asyncio.Semaphore(max_concurrency)
@@ -210,6 +212,13 @@ def main() -> None:
     args = parser.parse_args()
 
     companies = read_companies_from_csv(args.csv)
+    duplicates = find_duplicate_names(companies)
+    if duplicates:
+        print("Duplicate organization names found:")
+        for name in duplicates:
+            print(f"  {name}")
+
+    rows_with_missing_fields(companies, ["organization_name_url"])
     total_rows = len(companies)
 
     if total_rows > 100:

--- a/spreadsheet_parser/quality.py
+++ b/spreadsheet_parser/quality.py
@@ -1,0 +1,34 @@
+import logging
+from typing import Iterable, List, Sequence
+
+from .models import Company
+
+logger = logging.getLogger(__name__)
+
+
+def find_duplicate_names(companies: Sequence[Company]) -> List[str]:
+    """Return a sorted list of organization names that appear more than once."""
+    seen = set()
+    duplicates = set()
+    for company in companies:
+        name = company.organization_name.strip().lower()
+        if name in seen:
+            duplicates.add(company.organization_name)
+        else:
+            seen.add(name)
+    return sorted(duplicates)
+
+
+def rows_with_missing_fields(
+    companies: Sequence[Company], fields: Iterable[str]
+) -> List[int]:
+    """Return indexes of rows missing any of the specified fields."""
+    missing = []
+    for idx, company in enumerate(companies):
+        for field in fields:
+            value = getattr(company, field, None)
+            if value is None or value == "":
+                logger.warning("Row %d missing %s", idx, field)
+                missing.append(idx)
+                break
+    return missing

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,42 @@
+import unittest
+
+from parser import Company
+from spreadsheet_parser.quality import find_duplicate_names, rows_with_missing_fields
+
+
+class TestQualityChecks(unittest.TestCase):
+    def make_company(self, name, url="http://example.com"):
+        return Company(
+            organization_name=name,
+            organization_name_url=url,
+            estimated_revenue_range=None,
+            ipo_status=None,
+            operating_status=None,
+            acquisition_status=None,
+            company_type=None,
+            number_of_employees=None,
+            full_description=None,
+            industries="Tech",
+            headquarters_location=None,
+            description=None,
+            cb_rank=None,
+        )
+
+    def test_detect_duplicates(self):
+        comps = [
+            self.make_company("Acme"),
+            self.make_company("Globex"),
+            self.make_company("Acme"),
+        ]
+        dups = find_duplicate_names(comps)
+        self.assertEqual(dups, ["Acme"])
+
+    def test_missing_critical_fields(self):
+        c1 = self.make_company("Acme", url=None)
+        c2 = self.make_company("Globex", url="http://globex.com")
+        rows = rows_with_missing_fields([c1, c2], ["organization_name_url"])
+        self.assertEqual(rows, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `quality` module for duplicate detection and missing field logging
- integrate quality checks in `lookup_companies` before LLM calls
- test duplicate detection and missing critical fields

## Testing
- `python -m unittest discover -s tests -v`