### PR TITLE
Add model selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The repository also contains a simple helper, `fetch_company_web_info`, in
 `company_lookup.py`. It sends a prompt to OpenAI's API to retrieve a summary of a
 company from the web. The helper expects an ``OPENAI_API_KEY`` environment
 variable and, optionally, an ``OPENAI_MODEL`` variable to choose the model. If no
-model is specified, it defaults to ``gpt-4o``.
+model is specified, it defaults to ``gpt-4o``. The command-line tool described
+below also accepts a ``--model-name`` argument to override this value.
 
 You may provide just the company name or pass a `Company` object returned from
 `read_companies_from_csv` or `read_companies_from_xlsx`. 
@@ -70,10 +71,12 @@ which reads a CSV file and uses `fetch_company_web_info` to retrieve summaries f
 each company. The script processes only a limited number of rows (default is 5)
 and issues a warning if the CSV contains more than 100 lines.
 The tool now fetches results in parallel using asynchronous API calls. You can
-control the level of concurrency with the `--max-concurrency` flag (default is 5).
+control the level of concurrency with the `--max-concurrency` flag (default is 5)
+and select the OpenAI model with `--model-name` (default is `gpt-4o`).
 
 ```bash
-python lookup_companies.py path/to/companies.csv --max-lines 5 --max-concurrency 10
+python lookup_companies.py path/to/companies.csv \
+    --max-lines 5 --max-concurrency 10 --model-name gpt-4o
 ```
 
 This will fetch summaries and then display only the final report. The output

--- a/spreadsheet_parser/analysis.py
+++ b/spreadsheet_parser/analysis.py
@@ -526,7 +526,13 @@ def generate_final_report(
     return "\n".join(lines)
 
 
-async def run_async(companies, max_concurrency: int, output_dir: Path) -> None:
+async def run_async(
+    companies,
+    max_concurrency: int,
+    output_dir: Path,
+    *,
+    model_name: str = "gpt-4o",
+) -> None:
     from lookup_companies import async_fetch_company_web_info
     semaphore = asyncio.Semaphore(max_concurrency)
 
@@ -541,6 +547,7 @@ async def run_async(companies, max_concurrency: int, output_dir: Path) -> None:
         async with semaphore:
             return await async_fetch_company_web_info(
                 company.organization_name,
+                model=model_name,
                 return_cache_info=True,
             )
 


### PR DESCRIPTION
## Summary
- allow choosing the OpenAI model when running `lookup_companies.py`
- pass the model name through the async helpers so cache keys include the model
- document `--model-name` in README
- test that cache keys differ per model and adjust stubs

## Testing
- `python -m unittest discover -s tests -v`