### PR TITLE
Fix employee count parsing for non-string values

### DIFF
--- a/spreadsheet_parser/analysis.py
+++ b/spreadsheet_parser/analysis.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 from .llm import async_fetch_company_web_info, parse_llm_response
+from datetime import date, datetime
 
 DEFAULT_MAX_LINES = 5
 DEFAULT_MAX_CONCURRENCY = 5
@@ -19,7 +20,17 @@ _INDUSTRY_ALIASES = {
 
 def _employee_count(company: Company) -> Optional[float]:
     """Return an approximate employee count for a company."""
-    text = company.number_of_employees or ""
+    text = company.number_of_employees
+    if text is None:
+        return None
+
+    if isinstance(text, (int, float)):
+        return float(text)
+
+    if isinstance(text, (datetime, date)):
+        return None
+
+    text = str(text)
     digits = [int(d) for d in re.findall(r"\d+", text)]
     if not digits:
         return None

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -18,7 +18,9 @@ if "openai" not in sys.modules:
     )
     sys.modules["openai"] = openai_stub
 
-from spreadsheet_parser.analysis import _cb_rank_value
+from datetime import datetime
+from parser import Company
+from spreadsheet_parser.analysis import _cb_rank_value, _employee_count
 
 
 class TestCBRankValue(unittest.TestCase):
@@ -29,6 +31,32 @@ class TestCBRankValue(unittest.TestCase):
     def test_handles_strings(self):
         self.assertEqual(_cb_rank_value("1,234"), 1234)
         self.assertIsNone(_cb_rank_value(None))
+
+
+class TestEmployeeCount(unittest.TestCase):
+    def make_company(self, value):
+        return Company(
+            organization_name="Test",
+            organization_name_url=None,
+            estimated_revenue_range=None,
+            ipo_status=None,
+            operating_status=None,
+            acquisition_status=None,
+            company_type=None,
+            number_of_employees=value,
+            full_description=None,
+            industries=None,
+            headquarters_location=None,
+            description=None,
+            cb_rank=None,
+        )
+
+    def test_numeric_and_range(self):
+        self.assertEqual(_employee_count(self.make_company("5-10")), 7.5)
+        self.assertEqual(_employee_count(self.make_company(42)), 42.0)
+
+    def test_datetime_returns_none(self):
+        self.assertIsNone(_employee_count(self.make_company(datetime(2020, 1, 1))))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle datetimes and numbers when determining employee counts
- test that `_employee_count` works with numeric, range, and datetime values

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*