### PR TITLE
Add web search preview tool

### DIFF
--- a/spreadsheet_parser/llm.py
+++ b/spreadsheet_parser/llm.py
@@ -96,6 +96,7 @@ async def _fetch_with_cache(
             },
             {"role": "user", "content": prompt},
         ],
+        "tools": [{"type": "web_search_preview"}],
     }
     if seed is not None:
         kwargs["seed"] = seed

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -65,6 +65,9 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
 
                     args, kwargs = mock_client.chat.completions.create.call_args
                     self.assertEqual(kwargs["model"], "test-model")
+                    self.assertEqual(
+                        kwargs["tools"], [{"type": "web_search_preview"}]
+                    )
                     user_content = kwargs["messages"][1]["content"]
                     self.assertIn("Acme Corp", user_content)
                     self.assertIn(


### PR DESCRIPTION
## Summary
- use the `web_search_preview` tool in `fetch_company_web_info`
- test that `tools` parameter is passed when calling OpenAI

## Testing
- `python -m unittest discover -s tests -v`