### PR TITLE
Add report abstract generation via LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ installed, statistical tests are included in the report. T-tests compare
 employee counts and the derived size metric between supportive and
 non-supportive companies, while chi-squared tests examine whether IPO status,
 revenue range or CB rank are associated with support levels.
+The full text report is then submitted to the same language model and rewritten
+as a concise scientific paper abstract. This abstract is saved as
+``abstract.txt`` in the chosen output directory.
 
 Example snippet:
 

--- a/spreadsheet_parser/__init__.py
+++ b/spreadsheet_parser/__init__.py
@@ -6,6 +6,8 @@ from .llm import (
     fetch_company_web_info,
     async_fetch_company_web_info,
     parse_llm_response,
+    report_to_abstract,
+    async_report_to_abstract,
 )
 from .analysis import (
     DEFAULT_MAX_LINES,
@@ -30,6 +32,8 @@ __all__ = [
     "fetch_company_web_info",
     "async_fetch_company_web_info",
     "parse_llm_response",
+    "report_to_abstract",
+    "async_report_to_abstract",
     "DEFAULT_MAX_LINES",
     "DEFAULT_MAX_CONCURRENCY",
     "generate_final_report",

--- a/spreadsheet_parser/analysis.py
+++ b/spreadsheet_parser/analysis.py
@@ -5,7 +5,11 @@ from .models import Company
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from .llm import async_fetch_company_web_info, parse_llm_response
+from .llm import (
+    async_fetch_company_web_info,
+    parse_llm_response,
+    async_report_to_abstract,
+)
 from datetime import date, datetime
 
 DEFAULT_MAX_LINES = 5
@@ -706,6 +710,10 @@ async def run_async(
 
     report_path = output_dir / "final_report.txt"
     report_path.write_text(report, encoding="utf-8")
+    abstract = await async_report_to_abstract(report, model=model_name)
+    abstract_path = output_dir / "abstract.txt"
+    abstract_path.write_text(abstract or "", encoding="utf-8")
     print(f"Output table saved to {table_path}")
     print(f"Report saved to {report_path}")
+    print(f"Abstract saved to {abstract_path}")
 


### PR DESCRIPTION
## Summary
- add a function to rewrite final reports as a scientific abstract
- call the new helper from `run_async` and save `abstract.txt`
- expose new helpers in package API
- test that the prompt is created correctly and that `run_async` writes the abstract file
- document abstract generation in README

## Testing
- `python -m unittest discover -s tests -v`