### PR TITLE
Fix open file leak by reusing OpenAI client

### DIFF
--- a/spreadsheet_parser/analysis.py
+++ b/spreadsheet_parser/analysis.py
@@ -1,6 +1,8 @@
 import asyncio
 import csv
+import os
 import re
+import openai
 from .models import Company
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -552,7 +554,9 @@ async def run_async(
     model_name: str = "gpt-4o",
 ) -> None:
     from lookup_companies import async_fetch_company_web_info
+
     semaphore = asyncio.Semaphore(max_concurrency)
+    client = openai.AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
     stances: List[Optional[float]] = []
     subcats: List[Optional[str]] = []
@@ -567,6 +571,7 @@ async def run_async(
                 company.organization_name,
                 model=model_name,
                 return_cache_info=True,
+                client=client,
             )
 
     tasks = [asyncio.create_task(fetch(c)) for c in companies]
@@ -708,4 +713,6 @@ async def run_async(
     report_path.write_text(report, encoding="utf-8")
     print(f"Output table saved to {table_path}")
     print(f"Report saved to {report_path}")
+
+    await client.aclose()
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -195,6 +195,7 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
     @patch("company_lookup.openai.AsyncOpenAI", create=True)
     def test_async_cache_reused_for_same_seed(self, mock_async_openai):
         mock_client = mock_async_openai.return_value
+        mock_client.aclose = AsyncMock()
 
         async def fake_create(**kwargs):
             return type(
@@ -249,6 +250,7 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
     @patch("company_lookup.openai.AsyncOpenAI", create=True)
     def test_async_cache_not_reused_for_different_model(self, mock_async_openai):
         mock_client = mock_async_openai.return_value
+        mock_client.aclose = AsyncMock()
 
         async def fake_create(**kwargs):
             return type(
@@ -454,7 +456,7 @@ class TestRunAsync(unittest.TestCase):
             ),
         }
 
-        async def fake_fetch(name, *, return_cache_info=False, model=None):
+        async def fake_fetch(name, *, return_cache_info=False, model=None, client=None):
             return (responses[name], False)
 
         mock_fetch.side_effect = fake_fetch


### PR DESCRIPTION
## Summary
- reuse one `AsyncOpenAI` client in async runners
- close OpenAI clients when they are created internally
- update tests for new optional client argument

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai==1.37.1)*
- `python -m pytest -q` *(fails: No module named pytest)*