### PR TITLE
Fix missing biz_list entries when API calls fail

### DIFF
--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -62,6 +62,7 @@ async def _run_async(
             stances.append(None)
             subcats.append(None)
             just_list.append(None)
+            biz_list.append(None)
             table_rows.append(
                 [
                     company.organization_name,


### PR DESCRIPTION
## Summary
- ensure `biz_list` gets a `None` entry when `_run_async` encounters an exception

## Testing
- `python -m unittest discover -s tests -v` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'AsyncOpenAI')*