### PR TITLE
Add comment for openai patching

### DIFF
--- a/company_lookup.py
+++ b/company_lookup.py
@@ -1,3 +1,4 @@
+# Import required so tests can patch company_lookup.openai.OpenAI
 import openai
 from spreadsheet_parser import (
     fetch_company_web_info,


### PR DESCRIPTION
## Summary
- explain why `openai` import stays in `company_lookup`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*