### PR TITLE
Check OPENAI_API_KEY in _make_client

### DIFF
--- a/spreadsheet_parser/analysis.py
+++ b/spreadsheet_parser/analysis.py
@@ -580,10 +580,21 @@ def generate_final_report(
 
 
 async def _make_client():
-    """Return an OpenAI client compatible with old and new libraries."""
+    """Return an OpenAI client compatible with old and new libraries.
+
+    Raises
+    ------
+    EnvironmentError
+        If ``OPENAI_API_KEY`` is not defined in the environment.
+    """
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+
     if hasattr(openai, "AsyncOpenAI"):
-        return openai.AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-    return openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        return openai.AsyncOpenAI(api_key=api_key)
+    return openai.OpenAI(api_key=api_key)
 
 
 async def _collect_company_data(

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -484,7 +484,8 @@ class TestRunAsync(unittest.TestCase):
         ]
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            asyncio.run(run_async(companies, 1, pathlib.Path(tmpdir)))
+            with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+                asyncio.run(run_async(companies, 1, pathlib.Path(tmpdir)))
             csv_path = pathlib.Path(tmpdir) / "company_analysis.csv"
             abstract_path = pathlib.Path(tmpdir) / "abstract.txt"
             with csv_path.open(newline="") as f:


### PR DESCRIPTION
## Summary
- ensure `_make_client` validates that `OPENAI_API_KEY` exists before creating the client
- patch `TestRunAsync` to set `OPENAI_API_KEY`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*