### PR TITLE
Fix empty business model summaries

### DIFF
--- a/spreadsheet_parser/llm.py
+++ b/spreadsheet_parser/llm.py
@@ -77,7 +77,8 @@ async def _fetch_with_cache(
         "corporation, mark it accordingly. "
         "Return ONLY a JSON code block containing the sanitized fields along "
         "with a 'sub_category' string, numeric 'supportive' value, a boolean "
-        "'is_business', and a brief 'justification' for the rating."
+        "'is_business', a short 'business_model_summary', and a brief "
+        "'justification' for the rating."
     )
 
     cache_dir = Path.home() / "llm_cache"

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -83,12 +83,13 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertIn("sub_category", user_content)
         self.assertIn("justification", user_content)
         self.assertIn("is_business", user_content)
+        self.assertIn("business_model_summary", user_content)
 
     def test_parse_llm_response(self):
         text = (
             "Acme summary.\n"
             "```json\n"
-            '{"organization_name": "Acme", "supportive": 0.75, "sub_category": "Generative AI", "is_business": true}'
+            '{"organization_name": "Acme", "supportive": 0.75, "sub_category": "Generative AI", "is_business": true, "business_model_summary": "Acme summary"}'
             "\n```"
         )
         result = parse_llm_response(text)
@@ -98,6 +99,7 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertEqual(result.get("organization_name"), "Acme")
         self.assertEqual(result.get("sub_category"), "Generative AI")
         self.assertTrue(result.get("is_business"))
+        self.assertEqual(result.get("business_model_summary"), "Acme summary")
 
     def test_parse_llm_response_edge_cases(self):
         self.assertIsNone(parse_llm_response("nonsense"))


### PR DESCRIPTION
## Summary
- tell the LLM to include a `business_model_summary` field
- stop falling back to justification text when no summary is present
- update tests for the new instructions

## Testing
- `python -m unittest discover -s tests -v`