### PR TITLE
Add optional graph output

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ The full text report is then submitted to the same language model and rewritten
 as a concise scientific paper abstract. This abstract is saved as
 ``abstract.txt`` in the chosen output directory.
 
+If the optional ``matplotlib`` package is installed, a ``support_by_subcat.png``
+image is also created showing supportive and opposing company counts per AI
+sub-category. The bars include simple binomial error bars and are colored
+green/red for support and opposition respectively.
+
 Example snippet:
 
 ```text

--- a/lookup_companies.py
+++ b/lookup_companies.py
@@ -54,6 +54,7 @@ async def _run_async(
         subcats,
         just_list,
         biz_list,
+        plot_path=output_dir / "support_by_subcat.png",
     )
     print(report)
     print(f"Cached responses used: {cached_count}")


### PR DESCRIPTION
## Summary
- allow `generate_final_report` to save a bar chart when matplotlib is available
- pass the new plot path from the async runners
- document optional graph creation
- switch graph to subcategories with red/green bars and error bars

## Testing
- `python -m unittest discover -s tests -v`