### PR TITLE
Use real OpenAI library in tests

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,19 +1,7 @@
 import sys
-import types
 import unittest
 import os
 from unittest.mock import patch, AsyncMock, MagicMock
-
-# Provide a minimal openai stub if the real package is unavailable
-if "openai" not in sys.modules:
-
-    def make_client(*args, **kwargs):
-        return types.SimpleNamespace(
-            responses=types.SimpleNamespace(create=lambda **kwargs: None)
-        )
-
-    openai_stub = types.SimpleNamespace(OpenAI=make_client)
-    sys.modules["openai"] = openai_stub
 
 from datetime import datetime
 from parser import Company

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -3,20 +3,8 @@ import os
 import pathlib
 import sys
 import tempfile
-import types
 import unittest
 from unittest.mock import AsyncMock, patch
-
-# Provide a minimal openai stub if the real package is unavailable
-if "openai" not in sys.modules:
-
-    def make_client(*args, **kwargs):
-        return types.SimpleNamespace(
-            responses=types.SimpleNamespace(create=lambda **kwargs: None)
-        )
-
-    openai_stub = types.SimpleNamespace(OpenAI=make_client)
-    sys.modules["openai"] = openai_stub
 
 import csv
 from parser import Company

--- a/tests/test_csv_reader_additions.py
+++ b/tests/test_csv_reader_additions.py
@@ -1,11 +1,5 @@
-import types
-import sys
 import pathlib
 import unittest
-
-if "openai" not in sys.modules:
-    openai_stub = types.SimpleNamespace(OpenAI=lambda *a, **kw: None)
-    sys.modules["openai"] = openai_stub
 
 from parser import read_companies_from_csv
 

--- a/tests/test_lookup_companies.py
+++ b/tests/test_lookup_companies.py
@@ -1,16 +1,5 @@
 import sys
-import types
 import unittest
-
-if "openai" not in sys.modules:
-
-    def make_client(*args, **kwargs):
-        return types.SimpleNamespace(
-            responses=types.SimpleNamespace(create=lambda **kwargs: None)
-        )
-
-    openai_stub = types.SimpleNamespace(OpenAI=make_client)
-    sys.modules["openai"] = openai_stub
 
 from parser import Company
 


### PR DESCRIPTION
## Summary
- remove fallback OpenAI stubs from tests

## Testing
- `PYTHONPATH=. pytest -q`