### PR TITLE
Limit report to top industries

### DIFF
--- a/spreadsheet_parser/__init__.py
+++ b/spreadsheet_parser/__init__.py
@@ -12,6 +12,7 @@ from .llm import (
 from .analysis import (
     DEFAULT_MAX_LINES,
     DEFAULT_MAX_CONCURRENCY,
+    DEFAULT_MAX_INDUSTRIES,
     generate_final_report,
     percentile_ranks,
     run_async,
@@ -38,6 +39,7 @@ __all__ = [
     "async_report_to_abstract",
     "DEFAULT_MAX_LINES",
     "DEFAULT_MAX_CONCURRENCY",
+    "DEFAULT_MAX_INDUSTRIES",
     "generate_final_report",
     "percentile_ranks",
     "run_async",

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -425,6 +425,54 @@ class TestIndustryNormalization(unittest.TestCase):
         self.assertEqual(_industry(alias2), "Artificial Intelligence")
 
 
+class TestIndustryLimit(unittest.TestCase):
+    def test_top_25_only(self):
+        companies = []
+        stances = []
+        letters = [chr(ord('A') + i) for i in range(26)]
+        for letter in letters:
+            companies.append(
+                Company(
+                    organization_name=f"Co{letter}",
+                    organization_name_url=None,
+                    estimated_revenue_range=None,
+                    ipo_status=None,
+                    operating_status=None,
+                    acquisition_status=None,
+                    company_type=None,
+                    number_of_employees=None,
+                    full_description=None,
+                    industries=[f"Industry{letter}"],
+                    headquarters_location=None,
+                    description=None,
+                    cb_rank=None,
+                )
+            )
+            stances.append(0.9)
+        companies.append(
+            Company(
+                organization_name="Extra",
+                organization_name_url=None,
+                estimated_revenue_range=None,
+                ipo_status=None,
+                operating_status=None,
+                acquisition_status=None,
+                company_type=None,
+                number_of_employees=None,
+                full_description=None,
+                industries=["IndustryA"],
+                headquarters_location=None,
+                description=None,
+                cb_rank=None,
+            )
+        )
+        stances.append(0.9)
+
+        report = generate_final_report(companies, stances)
+        self.assertIn("IndustryA: supportive company found", report)
+        self.assertNotIn("IndustryZ: supportive company found", report)
+
+
 class TestRunAsync(unittest.TestCase):
     @patch("spreadsheet_parser.analysis._sample_data_quality_report", new_callable=AsyncMock)
     @patch("spreadsheet_parser.analysis.async_report_to_abstract", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary
- expose DEFAULT_MAX_INDUSTRIES constant
- trim industry sections in `generate_final_report` to show only the most frequent industries
- export new constant in `__init__`
- test that only top 25 industries are listed

## Testing
- `python -m pytest -q`