### PR TITLE
Refactor LLM output parsing with dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ You may provide just the company name or pass a `Company` object returned from
 `read_companies_from_csv` or `read_companies_from_xlsx`. 
 When a dataclass is supplied, all details from the CSV
 are included in the prompt sent to the LLM so that it can give a more informed
-summary. Responses are parsed with `parse_llm_response`, which now checks that
-the JSON payload contains `supportive` and `is_business` keys. If either key is
-missing the function returns `None` (or raises when called with
-`raise_on_missing=True`). In all cases the automated results should be reviewed
-manually.
+summary. Responses are parsed with `parse_llm_response`, which now returns a
+`LLMOutput` dataclass. The parser checks that the JSON payload contains the
+required `supportive` and `is_business` keys. If either key is missing or the
+payload is malformed the function logs a warning and returns `None`. In all
+cases the automated results should be reviewed manually.
 ## Lookup Script
 
 For convenience, the repository provides a small CLI script, `lookup_companies.py`,

--- a/parser.py
+++ b/parser.py
@@ -2,8 +2,9 @@
 
 from spreadsheet_parser import (
     Company,
+    LLMOutput,
     read_companies_from_csv,
     read_companies_from_xlsx,
 )
 
-__all__ = ["Company", "read_companies_from_csv", "read_companies_from_xlsx"]
+__all__ = ["Company", "LLMOutput", "read_companies_from_csv", "read_companies_from_xlsx"]

--- a/spreadsheet_parser/__init__.py
+++ b/spreadsheet_parser/__init__.py
@@ -1,6 +1,6 @@
 """Utility package for parsing company spreadsheets and looking up company info."""
 
-from .models import Company
+from .models import Company, LLMOutput
 from .csv_reader import read_companies_from_csv, read_companies_from_xlsx
 from .llm import (
     fetch_company_web_info,
@@ -29,6 +29,7 @@ _run_async = run_async
 
 __all__ = [
     "Company",
+    "LLMOutput",
     "read_companies_from_csv",
     "read_companies_from_xlsx",
     "fetch_company_web_info",

--- a/spreadsheet_parser/analysis.py
+++ b/spreadsheet_parser/analysis.py
@@ -798,16 +798,12 @@ async def _collect_company_data(
                 print(content)
                 parsed = parse_llm_response(content)
                 if parsed is not None:
-                    stance_val = parsed.get("supportive")
-                    justification = parsed.get("justification")
-                    subcat = parsed.get("sub_category")
-                    parsed_summary = (
-                        parsed.get("business_model_summary")
-                        or parsed.get("business_model")
-                        or parsed.get("summary")
-                    )
-                    is_biz = parsed.get("is_business")
-                    malformed = parsed.get("is_possibly_malformed")
+                    stance_val = parsed.supportive
+                    justification = parsed.justification
+                    subcat = parsed.sub_category
+                    parsed_summary = parsed.business_model_summary
+                    is_biz = parsed.is_business
+                    malformed = parsed.is_possibly_malformed
                 else:
                     parsed_summary = None
 

--- a/spreadsheet_parser/models.py
+++ b/spreadsheet_parser/models.py
@@ -36,3 +36,28 @@ CANONICAL_HEADERS: Dict[str, str] = {
     "description": "Description",
     "cb_rank": "CB Rank (Company)",
 }
+
+
+@dataclass
+class LLMOutput:
+    """Parsed fields returned by the language model."""
+
+    supportive: Optional[float]
+    is_business: Optional[bool]
+    sub_category: Optional[str] = None
+    business_model_summary: Optional[str] = None
+    justification: Optional[str] = None
+    is_possibly_malformed: Optional[bool] = None
+    raw: Optional[Dict[str, object]] = None
+
+    def __post_init__(self) -> None:
+        if self.sub_category is not None and not self.sub_category.strip():
+            self.sub_category = None
+        if self.justification is not None and not self.justification.strip():
+            self.justification = None
+        if (
+            self.business_model_summary is not None
+            and not self.business_model_summary.strip()
+        ):
+            self.business_model_summary = None
+


### PR DESCRIPTION
## Summary
- add new `LLMOutput` dataclass to hold parsed LLM results
- update `parse_llm_response` to return the dataclass and log warnings on malformed data
- refactor report generation to use the new dataclass
- export `LLMOutput` via public modules
- adjust README and tests

## Testing
- `PYTHONPATH=. pytest -q`