### PR TITLE
Add revenue/garble data quality checks

### DIFF
--- a/spreadsheet_parser/quality.py
+++ b/spreadsheet_parser/quality.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Iterable, List, Sequence
 
+from .analysis import _employee_count, _revenue_value
+
 from .models import Company
 
 logger = logging.getLogger(__name__)
@@ -32,3 +34,74 @@ def rows_with_missing_fields(
                 missing.append(idx)
                 break
     return missing
+
+
+def revenue_employee_outliers(
+    companies: Sequence[Company],
+    *,
+    employee_threshold: int = 50,
+    revenue_threshold: float = 1000.0,
+) -> List[int]:
+    """Return indexes where revenue is implausibly high for employee counts.
+
+    Parameters
+    ----------
+    companies:
+        Sequence of :class:`~spreadsheet_parser.models.Company` objects.
+    employee_threshold:
+        Maximum employee count considered "small".
+    revenue_threshold:
+        Minimum revenue in millions considered suspicious.
+    """
+
+    outliers: List[int] = []
+    for idx, company in enumerate(companies):
+        emp = _employee_count(company)
+        rev = _revenue_value(company.estimated_revenue_range)
+        if (
+            emp is not None
+            and rev is not None
+            and emp <= employee_threshold
+            and rev >= revenue_threshold
+        ):
+            logger.warning(
+                "Row %d unlikely revenue %s for %s employees",
+                idx,
+                company.estimated_revenue_range,
+                company.number_of_employees,
+            )
+            outliers.append(idx)
+    return outliers
+
+
+def rows_with_garbled_text(
+    companies: Sequence[Company], fields: Iterable[str] | None = None
+) -> List[int]:
+    """Return indexes of rows with suspiciously garbled text in ``fields``."""
+
+    if fields is None:
+        fields = ["industries", "headquarters_location", "description"]
+
+    garbled: List[int] = []
+    for idx, company in enumerate(companies):
+        for field in fields:
+            value = getattr(company, field, None)
+            if value is None:
+                continue
+            values = value if isinstance(value, list) else [value]
+            for val in values:
+                text = str(val)
+                if (
+                    len(text) > 100
+                    or "http://" in text
+                    or "https://" in text
+                    or "www." in text
+                    or "\n" in text
+                    or text.count(":") > 1
+                ):
+                    logger.warning("Row %d garbled %s: %s", idx, field, text)
+                    garbled.append(idx)
+                    break
+            if garbled and garbled[-1] == idx:
+                break
+    return garbled

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,7 +1,12 @@
 import unittest
 
 from parser import Company
-from spreadsheet_parser.quality import find_duplicate_names, rows_with_missing_fields
+from spreadsheet_parser.quality import (
+    find_duplicate_names,
+    rows_with_missing_fields,
+    revenue_employee_outliers,
+    rows_with_garbled_text,
+)
 
 
 class TestQualityChecks(unittest.TestCase):
@@ -36,6 +41,24 @@ class TestQualityChecks(unittest.TestCase):
         c2 = self.make_company("Globex", url="http://globex.com")
         rows = rows_with_missing_fields([c1, c2], ["organization_name_url"])
         self.assertEqual(rows, [0])
+
+    def test_revenue_employee_outliers(self):
+        c1 = self.make_company("TinyCo")
+        c1.number_of_employees = "1-10"
+        c1.estimated_revenue_range = "$1B to $10B"
+        c2 = self.make_company("BigCo")
+        c2.number_of_employees = "500-1000"
+        c2.estimated_revenue_range = "$1B to $10B"
+        rows = revenue_employee_outliers([c1, c2])
+        self.assertEqual(rows, [0])
+
+    def test_rows_with_garbled_text(self):
+        normal = self.make_company("NormalCo")
+        garbled = self.make_company("WeirdCo")
+        garbled.industries = ["http://example.com industry"]
+        garbled.headquarters_location = "City: http://bad"
+        rows = rows_with_garbled_text([normal, garbled])
+        self.assertEqual(rows, [1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `quality.py` with heuristics for unrealistic revenue vs. employee counts
- flag garbled text fields
- test new quality checks

## Testing
- `python -m pytest -q`