### PR TITLE
Add malformation_reason field for LLM output

### DIFF
--- a/spreadsheet_parser/__init__.py
+++ b/spreadsheet_parser/__init__.py
@@ -1,5 +1,9 @@
 """Utility package for parsing company spreadsheets and looking up company info."""
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
 from .models import Company, LLMOutput
 from .csv_reader import read_companies_from_csv, read_companies_from_xlsx
 from .llm import (

--- a/spreadsheet_parser/models.py
+++ b/spreadsheet_parser/models.py
@@ -48,6 +48,7 @@ class LLMOutput:
     business_model_summary: Optional[str] = None
     justification: Optional[str] = None
     is_possibly_malformed: Optional[bool] = None
+    malformation_reason: Optional[str] = None
     raw: Optional[Dict[str, object]] = None
 
     def __post_init__(self) -> None:
@@ -60,4 +61,7 @@ class LLMOutput:
             and not self.business_model_summary.strip()
         ):
             self.business_model_summary = None
+
+        if self.malformation_reason is not None and not self.malformation_reason.strip():
+            self.malformation_reason = None
 

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -72,6 +72,7 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertIn("justification", user_content)
         self.assertIn("is_business", user_content)
         self.assertIn("is_possibly_malformed", user_content)
+        self.assertIn("malformation_reason", user_content)
         self.assertIn("business_model_summary", user_content)
 
     def test_parse_llm_response(self):
@@ -90,6 +91,7 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertTrue(result.is_business)
         self.assertEqual(result.business_model_summary, "Acme summary")
         self.assertFalse(result.is_possibly_malformed)
+        self.assertIsNone(result.malformation_reason)
 
     def test_parse_llm_response_edge_cases(self):
         self.assertIsNone(parse_llm_response("nonsense"))
@@ -116,6 +118,17 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
 
         bool_no = '```json\n{"supportive": 0.5, "is_business": "no"}\n```'
         self.assertFalse(parse_llm_response(bool_no).is_business)
+
+    def test_parse_llm_response_malformation_reason(self):
+        text = (
+            "Intro.\n"
+            "```json\n"
+            '{"supportive": 0.4, "is_business": true, "is_possibly_malformed": true, "malformation_reason": "bad header"}'
+            "\n```"
+        )
+        result = parse_llm_response(text)
+        self.assertTrue(result.is_possibly_malformed)
+        self.assertEqual(result.malformation_reason, "bad header")
 
     def test_parse_llm_response_no_label(self):
         text = "Intro.\n" "```\n" '{"supportive": 0.6, "is_business": true}' "\n```"


### PR DESCRIPTION
## Summary
- extend `LLMOutput` dataclass with a `malformation_reason` field
- log when an LLM response indicates malformed input
- request the new field in the prompt
- configure logging on import so warnings are shown
- update tests for the new behaviour

## Testing
- `PYTHONPATH=. pytest -q`