### PR TITLE
Remove industry summary lines from report

### DIFF
--- a/spreadsheet_parser/analysis.py
+++ b/spreadsheet_parser/analysis.py
@@ -380,11 +380,6 @@ def generate_final_report(
     top_industries = set(sorted_inds[:max_industries])
 
     lines = ["Final Report:"]
-    for ind in sorted(top_industries):
-        if industry_data[ind]["supportive"] > 0:
-            lines.append(f"- {ind}: supportive company found")
-        else:
-            lines.append(f"- {ind}: no supportive company found")
 
     lines.append(f"Overall {total_support}/{total_companies} companies are supportive.")
     lines.append(f"Possibly malformed datapoints: {malformed_count}")

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -321,9 +321,8 @@ class TestFinalReport(unittest.TestCase):
             justifications=justifications,
             is_malformed_flags=[False, False, True],
         )
-        self.assertIn("Manufacturing: supportive company found", report)
-        self.assertIn("Technology: no supportive company found", report)
-        self.assertNotIn("Software: supportive company found", report)
+        # Industry summary lines should not be present
+        self.assertNotIn("supportive company found", report)
         self.assertIn("Overall 1/2 companies are supportive", report)
         self.assertIn("Supportive companies by industry", report)
         self.assertIn("  Manufacturing: #################### (1/1)", report)
@@ -469,8 +468,7 @@ class TestIndustryLimit(unittest.TestCase):
         stances.append(0.9)
 
         report = generate_final_report(companies, stances)
-        self.assertIn("IndustryA: supportive company found", report)
-        self.assertNotIn("IndustryZ: supportive company found", report)
+        self.assertNotIn("supportive company found", report)
 
 
 class TestRunAsync(unittest.TestCase):


### PR DESCRIPTION
## Summary
- drop industry summary lines from final report output
- remove unused industry exclusion constant
- update unit tests accordingly

## Testing
- `PYTHONPATH=. pytest -q`