### PR TITLE
Refine malformation handling

### DIFF
--- a/spreadsheet_parser/llm.py
+++ b/spreadsheet_parser/llm.py
@@ -84,8 +84,11 @@ async def _fetch_with_cache(
         "'is_business', a short 'business_model_summary', a brief "
         "'justification' for the rating, and a boolean "
         "'is_possibly_malformed' flag indicating if the input data might be "
-        "corrupted or missing. If you set this flag to true also include a "
-        "'malformation_reason' string explaining what seems wrong."
+        "corrupted or missing. The decision about malformed data must be "
+        "based solely on the spreadsheet row provided above; web search "
+        "results should not influence it. If you set this flag to true also "
+        "include a 'malformation_reason' string explaining what seems wrong. "
+        "Leave 'malformation_reason' blank if the data appears valid."
     )
 
     cache_dir = Path.home() / "llm_cache"

--- a/spreadsheet_parser/models.py
+++ b/spreadsheet_parser/models.py
@@ -65,3 +65,6 @@ class LLMOutput:
         if self.malformation_reason is not None and not self.malformation_reason.strip():
             self.malformation_reason = None
 
+        if not self.is_possibly_malformed:
+            self.malformation_reason = None
+

--- a/tests/test_company_lookup.py
+++ b/tests/test_company_lookup.py
@@ -130,6 +130,17 @@ class TestFetchCompanyWebInfo(unittest.TestCase):
         self.assertTrue(result.is_possibly_malformed)
         self.assertEqual(result.malformation_reason, "bad header")
 
+    def test_parse_llm_response_reason_cleared_when_flag_false(self):
+        text = (
+            "Intro.\n"
+            "```json\n"
+            '{"supportive": 0.7, "is_business": true, "is_possibly_malformed": false, "malformation_reason": "bad header"}'
+            "\n```"
+        )
+        result = parse_llm_response(text)
+        self.assertFalse(result.is_possibly_malformed)
+        self.assertIsNone(result.malformation_reason)
+
     def test_parse_llm_response_no_label(self):
         text = "Intro.\n" "```\n" '{"supportive": 0.6, "is_business": true}' "\n```"
         result = parse_llm_response(text)


### PR DESCRIPTION
## Summary
- ensure malformation_reason is cleared unless the malformed flag is set
- clarify that malformed status must be judged from the spreadsheet data alone
- test that malformation_reason is ignored when the flag is false

## Testing
- `PYTHONPATH=. pytest -q`