### PR TITLE
Add multi-CSV loader

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -4,7 +4,14 @@ from spreadsheet_parser import (
     Company,
     LLMOutput,
     read_companies_from_csv,
+    read_companies_from_csvs,
     read_companies_from_xlsx,
 )
 
-__all__ = ["Company", "LLMOutput", "read_companies_from_csv", "read_companies_from_xlsx"]
+__all__ = [
+    "Company",
+    "LLMOutput",
+    "read_companies_from_csv",
+    "read_companies_from_csvs",
+    "read_companies_from_xlsx",
+]

--- a/spreadsheet_parser/__init__.py
+++ b/spreadsheet_parser/__init__.py
@@ -5,7 +5,11 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 from .models import Company, LLMOutput
-from .csv_reader import read_companies_from_csv, read_companies_from_xlsx
+from .csv_reader import (
+    read_companies_from_csv,
+    read_companies_from_xlsx,
+    read_companies_from_csvs,
+)
 from .llm import (
     fetch_company_web_info,
     async_fetch_company_web_info,
@@ -36,6 +40,7 @@ __all__ = [
     "Company",
     "LLMOutput",
     "read_companies_from_csv",
+    "read_companies_from_csvs",
     "read_companies_from_xlsx",
     "fetch_company_web_info",
     "async_fetch_company_web_info",

--- a/tests/test_csv_reader_additions.py
+++ b/tests/test_csv_reader_additions.py
@@ -1,7 +1,7 @@
 import pathlib
 import unittest
 
-from parser import read_companies_from_csv
+from parser import read_companies_from_csv, read_companies_from_csvs
 
 class TestCSVReaderAdditions(unittest.TestCase):
     def test_employee_range_correction(self):
@@ -15,6 +15,30 @@ class TestCSVReaderAdditions(unittest.TestCase):
         companies = read_companies_from_csv(path)
         self.assertEqual(len(companies), 3)
         self.assertTrue(companies[0].organization_name.startswith("OpenAI"))
+
+    def test_read_multiple_with_filename_defaults(self):
+        import tempfile
+        from pathlib import Path
+
+        csv_text = (
+            "Organization Name,IPO Status,Operating Status,Estimated Revenue Range,Number of Employees\n"
+            "Acme Corp,,,,\n"
+            "Globex,Public,Active,$10M-$50M,51-100\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p1 = Path(tmpdir) / "FS_ActivePrivate_1Bto100B_51plus.csv"
+            p1.write_text(csv_text, encoding="utf-8")
+            p2 = Path(tmpdir) / "FS_ActivePrivate_1Bto100B_101plus.csv"
+            p2.write_text(csv_text, encoding="utf-8")
+            with self.assertLogs("spreadsheet_parser.csv_reader", level="WARNING") as cm:
+                companies = read_companies_from_csvs([p1, p2])
+        self.assertEqual(len(companies), 4)
+        self.assertEqual(companies[0].ipo_status, "Private")
+        self.assertEqual(companies[0].operating_status, "Active")
+        self.assertEqual(companies[0].estimated_revenue_range, "$1B to $100B")
+        self.assertEqual(companies[0].number_of_employees, "51+")
+        log_text = "\n".join(cm.output)
+        self.assertIn("conflicts with filename", log_text)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `read_companies_from_csvs` to load multiple search result files
- extract metadata from filename and warn on conflicts
- re-export helper in `parser.py` and package `__init__`
- test new loader functionality

## Testing
- `PYTHONPATH=$PWD pytest -q`