### PR TITLE
Use directory input in lookup_companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ cases the automated results should be reviewed manually.
 ## Lookup Script
 
 For convenience, the repository provides a small CLI script, `lookup_companies.py`,
-which reads a CSV file and uses `fetch_company_web_info` to retrieve summaries for
+which reads CSV files from a directory and uses `fetch_company_web_info` to retrieve summaries for
 each company. The script processes only a limited number of rows (default is 5)
-and issues a warning if the CSV contains more than 100 lines.
+and issues a warning if the combined files contain more than 100 lines.
 The tool now fetches results in parallel using asynchronous API calls. You can
 control the level of concurrency with the `--max-concurrency` flag (default is 5)
 and select the OpenAI model with `--model-name` (default is `gpt-4o`).
 
 ```bash
-python lookup_companies.py path/to/companies.csv \
+python lookup_companies.py path/to/csv_directory \
     --max-lines 5 --max-concurrency 10 --model-name gpt-4o
 ```
 


### PR DESCRIPTION
## Summary
- read all company CSVs in a directory when running `lookup_companies.py`
- update README usage instructions accordingly

## Testing
- `PYTHONPATH=. pytest -q`